### PR TITLE
fix: properly handle get value with falsy values

### DIFF
--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -790,7 +790,8 @@ const builtins = {
   // 10.3.4.10 Context function
 
   'get value': fn(function(m, key) {
-    return getFromContext(key, m) || null;
+    const value = getFromContext(key, m);
+    return value != undefined ? value : null;
   }, [ 'context', 'string' ]),
 
   'get entries': fn(function(m) {

--- a/test/builtins-spec.js
+++ b/test/builtins-spec.js
@@ -626,6 +626,8 @@ describe('builtin functions', function() {
   describe('Context', function() {
 
     expr('get value({key1 : "value1"}, "key1")', 'value1');
+    expr('get value({key1 : 0}, "key1")', 0);
+    expr('get value({key1 : false}, "key1")', false);
     expr('get value({key1 : "value1"}, "unexistent-key")', null);
     expr('get value({key+    +1 : "value1"}, "key + + 1")', 'value1');
 


### PR DESCRIPTION
Closes #76

Get value was doing an `|| null` in the logic which was converting all falsy values to null, which is obviously not what we want as behavior.