### PR TITLE
Properly parse special characters `\r\n\t`

### DIFF
--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -1245,12 +1245,14 @@ function parseString(str: string) {
     str = str.slice(0, -1);
   }
 
-
-  return str.replace(/(\\")|(\\\\)|(\\u[a-fA-F0-9]{5,6})|((?:\\u[a-fA-F0-9]{1,4})+)/ig, function(substring: string, ...groups: any[]) {
+  return str.replace(/(\\")|(\\\\)|(\\n)|(\\r)|(\\t)|(\\u[a-fA-F0-9]{5,6})|((?:\\u[a-fA-F0-9]{1,4})+)/ig, function(substring: string, ...groups: any[]) {
 
     const [
       quotes,
-      escape,
+      backslash,
+      newline,
+      carriageReturn,
+      tab,
       codePoint,
       charCodes
     ] = groups;
@@ -1259,7 +1261,19 @@ function parseString(str: string) {
       return '"';
     }
 
-    if (escape) {
+    if (newline) {
+      return '\n';
+    }
+
+    if (carriageReturn) {
+      return '\r';
+    }
+
+    if (tab) {
+      return '\t';
+    }
+
+    if (backslash) {
       return '\\';
     }
 

--- a/test/builtins-spec.js
+++ b/test/builtins-spec.js
@@ -1,6 +1,10 @@
 import { expect } from './helpers.js';
 
 import {
+  inspect
+} from 'node:util';
+
+import {
   evaluate
 } from '../dist/index.esm.js';
 
@@ -703,7 +707,7 @@ function createExprVerifier(options) {
     context
   ] = args;
 
-  const name = `${expression}${context ? ' { ' + Object.keys(context).join(', ') + ' }' : ''}`;
+  const name = `${expression}${context ? ` ${ inspect(context) }` : ''}`;
 
   it(name, function() {
     const output = evaluate(expression, context || {});

--- a/test/interpreter-spec.js
+++ b/test/interpreter-spec.js
@@ -703,7 +703,15 @@ describe('interpreter', function() {
       expr('"foo"', 'foo');
 
       expr('"\\""', '"');
+      expr('"\\n"', '\n');
+      expr('"\\"', '\\');
+      expr('"\\t"', '\t');
+      expr('"\\r"', '\r');
+
+      expr('"\\\\n"', '\\n');
       expr('"\\\\"', '\\');
+
+      expr('"\\s"', '\\s');
 
       expr('"\\ud83d\\udc0e\\uD83D\\UDE00"', '🐎😀');
       expr('"\\U01F40E"', '🐎');


### PR DESCRIPTION
We previously did not treat them as "raw" characters.