### PR TITLE
chore(builtins): adopt unified pattern parsing for `split` function

### DIFF
--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -387,7 +387,9 @@ const builtins = {
   }, [ 'string', 'string' ]),
 
   'split': fn(function(string, delimiter) {
-    return string.split(new RegExp(delimiter, 'u'));
+    const regexp = createRegexp(delimiter, '', '');
+
+    return regexp && string.split(regexp);
   }, [ 'string', 'string' ]),
 
   'string join': fn(function(list, delimiter) {

--- a/test/builtins-spec.js
+++ b/test/builtins-spec.js
@@ -274,6 +274,8 @@ describe('builtin functions', function() {
 
     expr('split(string: "foo🐎bar", delimiter: "o.b")', [ 'fo', 'ar' ]);
 
+    expr('split("foo bar", "[a-z")', null);
+
     expr('string join(123, "X")', null);
 
     expr('string join(123, "X")', null);


### PR DESCRIPTION
Related to https://github.com/nikku/feelin/pull/96