### PR TITLE
Support chained contexts in `InExpressions`

### DIFF
--- a/docs/tck-results.json
+++ b/docs/tck-results.json
@@ -1,7 +1,7 @@
 {
-  "passes": 1618,
+  "passes": 1619,
   "pending": 302,
-  "failures": 96,
+  "failures": 95,
   "tests": 2016,
   "failedTests": [
     "tck - 0050-feel-abs-function-test-01.xml - 011 - abs(duration(\"-P1D\")) === duration(\"P1D\")",
@@ -32,7 +32,6 @@
     "tck - 0079-feel-string-function-test-01.xml - dt_duration_002 - string(duration(\"-P1D\")) === \"-P1D\"",
     "tck - 0079-feel-string-function-test-01.xml - ym_duration_002 - string(duration(\"-P1Y\")) === \"-P1Y\"",
     "tck - 0079-feel-string-function-test-01.xml - ym_duration_003 - string(duration(\"P0Y\")) === \"P0M\"",
-    "tck - 0084-feel-for-loops-test-01.xml - decision_015 - for x in [ [1,2], [3,4] ], y in x return y === [1,2,3,4]",
     "tck - 0084-feel-for-loops-test-01.xml - decision_017 - for i in @\"1980-01-01\"..@\"1980-01-03\" return i === [date(\"1980-01-01\"),date(\"1980-01-02\"),date(\"1980-01-03\")]",
     "tck - 0084-feel-for-loops-test-01.xml - decision_018 - for i in @\"1980-01-03\"..@\"1980-01-01\" return i === [date(\"1980-01-03\"),date(\"1980-01-02\"),date(\"1980-01-01\")]",
     "tck - 0084-feel-for-loops-test-01.xml - decision_019 - for i in \"a\"..\"z\" return i === null",

--- a/docs/tck-results.svg
+++ b/docs/tck-results.svg
@@ -8,9 +8,9 @@
   </defs>
 
   <g clip-path="url(#round-corners)">
-    <rect width="80.2579365079365" height="5" fill="rgb(26, 127, 55)" x="0" y="0" />
-    <rect width="14.98015873015873" height="5" fill="rgb(200, 200, 200)" x="80.2579365079365" y="0" />
-    <rect width="4.761904761904762" height="5" fill="rgb(209, 36, 47)" x="95.23809523809524" y="0" />
+    <rect width="80.30753968253968" height="5" fill="rgb(26, 127, 55)" x="0" y="0" />
+    <rect width="14.98015873015873" height="5" fill="rgb(200, 200, 200)" x="80.30753968253968" y="0" />
+    <rect width="4.712301587301587" height="5" fill="rgb(209, 36, 47)" x="95.28769841269842" y="0" />
   </g>
 
 </svg>

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,8 @@
         "source-map-support": "^0.5.21",
         "strip-indent": "^4.0.0",
         "tslib": "^2.8.1",
-        "typescript": "^5.7.2",
-        "typescript-eslint": "^8.18.2"
+        "typescript": "^5.7.3",
+        "typescript-eslint": "^8.19.1"
       },
       "engines": {
         "node": "*"
@@ -628,21 +628,21 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.18.2.tgz",
-      "integrity": "sha512-adig4SzPLjeQ0Tm+jvsozSGiCliI2ajeURDGHjZ2llnA+A67HihCQ+a3amtPhUakd1GlwHxSRvzOZktbEvhPPg==",
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.19.1.tgz",
+      "integrity": "sha512-tJzcVyvvb9h/PB96g30MpxACd9IrunT7GF9wfA9/0TJ1LxGOJx1TdPzSbBBnNED7K9Ka8ybJsnEpiXPktolTLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.18.2",
-        "@typescript-eslint/type-utils": "8.18.2",
-        "@typescript-eslint/utils": "8.18.2",
-        "@typescript-eslint/visitor-keys": "8.18.2",
+        "@typescript-eslint/scope-manager": "8.19.1",
+        "@typescript-eslint/type-utils": "8.19.1",
+        "@typescript-eslint/utils": "8.19.1",
+        "@typescript-eslint/visitor-keys": "8.19.1",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^1.3.0"
+        "ts-api-utils": "^2.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -658,16 +658,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.18.2.tgz",
-      "integrity": "sha512-y7tcq4StgxQD4mDr9+Jb26dZ+HTZ/SkfqpXSiqeUXZHxOUyjWDKsmwKhJ0/tApR08DgOhrFAoAhyB80/p3ViuA==",
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.19.1.tgz",
+      "integrity": "sha512-67gbfv8rAwawjYx3fYArwldTQKoYfezNUT4D5ioWetr/xCrxXxvleo3uuiFuKfejipvq+og7mjz3b0G2bVyUCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.18.2",
-        "@typescript-eslint/types": "8.18.2",
-        "@typescript-eslint/typescript-estree": "8.18.2",
-        "@typescript-eslint/visitor-keys": "8.18.2",
+        "@typescript-eslint/scope-manager": "8.19.1",
+        "@typescript-eslint/types": "8.19.1",
+        "@typescript-eslint/typescript-estree": "8.19.1",
+        "@typescript-eslint/visitor-keys": "8.19.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -683,14 +683,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.18.2.tgz",
-      "integrity": "sha512-YJFSfbd0CJjy14r/EvWapYgV4R5CHzptssoag2M7y3Ra7XNta6GPAJPPP5KGB9j14viYXyrzRO5GkX7CRfo8/g==",
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.19.1.tgz",
+      "integrity": "sha512-60L9KIuN/xgmsINzonOcMDSB8p82h95hoBfSBtXuO4jlR1R9L1xSkmVZKgCPVfavDlXihh4ARNjXhh1gGnLC7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.18.2",
-        "@typescript-eslint/visitor-keys": "8.18.2"
+        "@typescript-eslint/types": "8.19.1",
+        "@typescript-eslint/visitor-keys": "8.19.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -701,16 +701,16 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.18.2.tgz",
-      "integrity": "sha512-AB/Wr1Lz31bzHfGm/jgbFR0VB0SML/hd2P1yxzKDM48YmP7vbyJNHRExUE/wZsQj2wUCvbWH8poNHFuxLqCTnA==",
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.19.1.tgz",
+      "integrity": "sha512-Rp7k9lhDKBMRJB/nM9Ksp1zs4796wVNyihG9/TU9R6KCJDNkQbc2EOKjrBtLYh3396ZdpXLtr/MkaSEmNMtykw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.18.2",
-        "@typescript-eslint/utils": "8.18.2",
+        "@typescript-eslint/typescript-estree": "8.19.1",
+        "@typescript-eslint/utils": "8.19.1",
         "debug": "^4.3.4",
-        "ts-api-utils": "^1.3.0"
+        "ts-api-utils": "^2.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -725,9 +725,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.18.2.tgz",
-      "integrity": "sha512-Z/zblEPp8cIvmEn6+tPDIHUbRu/0z5lqZ+NvolL5SvXWT5rQy7+Nch83M0++XzO0XrWRFWECgOAyE8bsJTl1GQ==",
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.19.1.tgz",
+      "integrity": "sha512-JBVHMLj7B1K1v1051ZaMMgLW4Q/jre5qGK0Ew6UgXz1Rqh+/xPzV1aW581OM00X6iOfyr1be+QyW8LOUf19BbA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -739,20 +739,20 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.18.2.tgz",
-      "integrity": "sha512-WXAVt595HjpmlfH4crSdM/1bcsqh+1weFRWIa9XMTx/XHZ9TCKMcr725tLYqWOgzKdeDrqVHxFotrvWcEsk2Tg==",
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.19.1.tgz",
+      "integrity": "sha512-jk/TZwSMJlxlNnqhy0Eod1PNEvCkpY6MXOXE/WLlblZ6ibb32i2We4uByoKPv1d0OD2xebDv4hbs3fm11SMw8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.18.2",
-        "@typescript-eslint/visitor-keys": "8.18.2",
+        "@typescript-eslint/types": "8.19.1",
+        "@typescript-eslint/visitor-keys": "8.19.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
-        "ts-api-utils": "^1.3.0"
+        "ts-api-utils": "^2.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -792,16 +792,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.18.2.tgz",
-      "integrity": "sha512-Cr4A0H7DtVIPkauj4sTSXVl+VBWewE9/o40KcF3TV9aqDEOWoXF3/+oRXNby3DYzZeCATvbdksYsGZzplwnK/Q==",
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.19.1.tgz",
+      "integrity": "sha512-IxG5gLO0Ne+KaUc8iW1A+XuKLd63o4wlbI1Zp692n1xojCl/THvgIKXJXBZixTh5dd5+yTJ/VXH7GJaaw21qXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.18.2",
-        "@typescript-eslint/types": "8.18.2",
-        "@typescript-eslint/typescript-estree": "8.18.2"
+        "@typescript-eslint/scope-manager": "8.19.1",
+        "@typescript-eslint/types": "8.19.1",
+        "@typescript-eslint/typescript-estree": "8.19.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -816,13 +816,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.18.2.tgz",
-      "integrity": "sha512-zORcwn4C3trOWiCqFQP1x6G3xTRyZ1LYydnj51cRnJ6hxBlr/cKPckk+PKPUw/fXmvfKTcw7bwY3w9izgx5jZw==",
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.19.1.tgz",
+      "integrity": "sha512-fzmjU8CHK853V/avYZAvuVut3ZTfwN5YtMaoi+X9Y9MA9keaWNHC3zEQ9zvyX/7Hj+5JkNyK1l7TOR2hevHB6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.18.2",
+        "@typescript-eslint/types": "8.19.1",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -4300,16 +4300,16 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
-      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.0.tgz",
+      "integrity": "sha512-xCt/TOAc+EOHS1XPnijD3/yzpH6qg2xppZO1YDqGoVsNXfQfzHpOdNuXwrwOU8u4ITXJyDCTyt8w5g1sZv9ynQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=18.12"
       },
       "peerDependencies": {
-        "typescript": ">=4.2.0"
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/tslib": {
@@ -4427,9 +4427,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4441,15 +4441,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.18.2.tgz",
-      "integrity": "sha512-KuXezG6jHkvC3MvizeXgupZzaG5wjhU3yE8E7e6viOvAvD9xAWYp8/vy0WULTGe9DYDWcQu7aW03YIV3mSitrQ==",
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.19.1.tgz",
+      "integrity": "sha512-LKPUQpdEMVOeKluHi8md7rwLcoXHhwvWp3x+sJkMuq3gGm9yaYJtPo8sRZSblMFJ5pcOGCAak/scKf1mvZDlQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.18.2",
-        "@typescript-eslint/parser": "8.18.2",
-        "@typescript-eslint/utils": "8.18.2"
+        "@typescript-eslint/eslint-plugin": "8.19.1",
+        "@typescript-eslint/parser": "8.19.1",
+        "@typescript-eslint/utils": "8.19.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5160,77 +5160,77 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.18.2.tgz",
-      "integrity": "sha512-adig4SzPLjeQ0Tm+jvsozSGiCliI2ajeURDGHjZ2llnA+A67HihCQ+a3amtPhUakd1GlwHxSRvzOZktbEvhPPg==",
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.19.1.tgz",
+      "integrity": "sha512-tJzcVyvvb9h/PB96g30MpxACd9IrunT7GF9wfA9/0TJ1LxGOJx1TdPzSbBBnNED7K9Ka8ybJsnEpiXPktolTLg==",
       "dev": true,
       "requires": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.18.2",
-        "@typescript-eslint/type-utils": "8.18.2",
-        "@typescript-eslint/utils": "8.18.2",
-        "@typescript-eslint/visitor-keys": "8.18.2",
+        "@typescript-eslint/scope-manager": "8.19.1",
+        "@typescript-eslint/type-utils": "8.19.1",
+        "@typescript-eslint/utils": "8.19.1",
+        "@typescript-eslint/visitor-keys": "8.19.1",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^1.3.0"
+        "ts-api-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.18.2.tgz",
-      "integrity": "sha512-y7tcq4StgxQD4mDr9+Jb26dZ+HTZ/SkfqpXSiqeUXZHxOUyjWDKsmwKhJ0/tApR08DgOhrFAoAhyB80/p3ViuA==",
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.19.1.tgz",
+      "integrity": "sha512-67gbfv8rAwawjYx3fYArwldTQKoYfezNUT4D5ioWetr/xCrxXxvleo3uuiFuKfejipvq+og7mjz3b0G2bVyUCw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "8.18.2",
-        "@typescript-eslint/types": "8.18.2",
-        "@typescript-eslint/typescript-estree": "8.18.2",
-        "@typescript-eslint/visitor-keys": "8.18.2",
+        "@typescript-eslint/scope-manager": "8.19.1",
+        "@typescript-eslint/types": "8.19.1",
+        "@typescript-eslint/typescript-estree": "8.19.1",
+        "@typescript-eslint/visitor-keys": "8.19.1",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.18.2.tgz",
-      "integrity": "sha512-YJFSfbd0CJjy14r/EvWapYgV4R5CHzptssoag2M7y3Ra7XNta6GPAJPPP5KGB9j14viYXyrzRO5GkX7CRfo8/g==",
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.19.1.tgz",
+      "integrity": "sha512-60L9KIuN/xgmsINzonOcMDSB8p82h95hoBfSBtXuO4jlR1R9L1xSkmVZKgCPVfavDlXihh4ARNjXhh1gGnLC7Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "8.18.2",
-        "@typescript-eslint/visitor-keys": "8.18.2"
+        "@typescript-eslint/types": "8.19.1",
+        "@typescript-eslint/visitor-keys": "8.19.1"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.18.2.tgz",
-      "integrity": "sha512-AB/Wr1Lz31bzHfGm/jgbFR0VB0SML/hd2P1yxzKDM48YmP7vbyJNHRExUE/wZsQj2wUCvbWH8poNHFuxLqCTnA==",
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.19.1.tgz",
+      "integrity": "sha512-Rp7k9lhDKBMRJB/nM9Ksp1zs4796wVNyihG9/TU9R6KCJDNkQbc2EOKjrBtLYh3396ZdpXLtr/MkaSEmNMtykw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "8.18.2",
-        "@typescript-eslint/utils": "8.18.2",
+        "@typescript-eslint/typescript-estree": "8.19.1",
+        "@typescript-eslint/utils": "8.19.1",
         "debug": "^4.3.4",
-        "ts-api-utils": "^1.3.0"
+        "ts-api-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.18.2.tgz",
-      "integrity": "sha512-Z/zblEPp8cIvmEn6+tPDIHUbRu/0z5lqZ+NvolL5SvXWT5rQy7+Nch83M0++XzO0XrWRFWECgOAyE8bsJTl1GQ==",
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.19.1.tgz",
+      "integrity": "sha512-JBVHMLj7B1K1v1051ZaMMgLW4Q/jre5qGK0Ew6UgXz1Rqh+/xPzV1aW581OM00X6iOfyr1be+QyW8LOUf19BbA==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.18.2.tgz",
-      "integrity": "sha512-WXAVt595HjpmlfH4crSdM/1bcsqh+1weFRWIa9XMTx/XHZ9TCKMcr725tLYqWOgzKdeDrqVHxFotrvWcEsk2Tg==",
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.19.1.tgz",
+      "integrity": "sha512-jk/TZwSMJlxlNnqhy0Eod1PNEvCkpY6MXOXE/WLlblZ6ibb32i2We4uByoKPv1d0OD2xebDv4hbs3fm11SMw8Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "8.18.2",
-        "@typescript-eslint/visitor-keys": "8.18.2",
+        "@typescript-eslint/types": "8.19.1",
+        "@typescript-eslint/visitor-keys": "8.19.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
-        "ts-api-utils": "^1.3.0"
+        "ts-api-utils": "^2.0.0"
       },
       "dependencies": {
         "brace-expansion": {
@@ -5254,24 +5254,24 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.18.2.tgz",
-      "integrity": "sha512-Cr4A0H7DtVIPkauj4sTSXVl+VBWewE9/o40KcF3TV9aqDEOWoXF3/+oRXNby3DYzZeCATvbdksYsGZzplwnK/Q==",
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.19.1.tgz",
+      "integrity": "sha512-IxG5gLO0Ne+KaUc8iW1A+XuKLd63o4wlbI1Zp692n1xojCl/THvgIKXJXBZixTh5dd5+yTJ/VXH7GJaaw21qXA==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.18.2",
-        "@typescript-eslint/types": "8.18.2",
-        "@typescript-eslint/typescript-estree": "8.18.2"
+        "@typescript-eslint/scope-manager": "8.19.1",
+        "@typescript-eslint/types": "8.19.1",
+        "@typescript-eslint/typescript-estree": "8.19.1"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.18.2.tgz",
-      "integrity": "sha512-zORcwn4C3trOWiCqFQP1x6G3xTRyZ1LYydnj51cRnJ6hxBlr/cKPckk+PKPUw/fXmvfKTcw7bwY3w9izgx5jZw==",
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.19.1.tgz",
+      "integrity": "sha512-fzmjU8CHK853V/avYZAvuVut3ZTfwN5YtMaoi+X9Y9MA9keaWNHC3zEQ9zvyX/7Hj+5JkNyK1l7TOR2hevHB6Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "8.18.2",
+        "@typescript-eslint/types": "8.19.1",
         "eslint-visitor-keys": "^4.2.0"
       },
       "dependencies": {
@@ -7709,9 +7709,9 @@
       }
     },
     "ts-api-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
-      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.0.tgz",
+      "integrity": "sha512-xCt/TOAc+EOHS1XPnijD3/yzpH6qg2xppZO1YDqGoVsNXfQfzHpOdNuXwrwOU8u4ITXJyDCTyt8w5g1sZv9ynQ==",
       "dev": true,
       "requires": {}
     },
@@ -7795,20 +7795,20 @@
       }
     },
     "typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true
     },
     "typescript-eslint": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.18.2.tgz",
-      "integrity": "sha512-KuXezG6jHkvC3MvizeXgupZzaG5wjhU3yE8E7e6viOvAvD9xAWYp8/vy0WULTGe9DYDWcQu7aW03YIV3mSitrQ==",
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.19.1.tgz",
+      "integrity": "sha512-LKPUQpdEMVOeKluHi8md7rwLcoXHhwvWp3x+sJkMuq3gGm9yaYJtPo8sRZSblMFJ5pcOGCAak/scKf1mvZDlQw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/eslint-plugin": "8.18.2",
-        "@typescript-eslint/parser": "8.18.2",
-        "@typescript-eslint/utils": "8.18.2"
+        "@typescript-eslint/eslint-plugin": "8.19.1",
+        "@typescript-eslint/parser": "8.19.1",
+        "@typescript-eslint/utils": "8.19.1"
       }
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "source-map-support": "^0.5.21",
     "strip-indent": "^4.0.0",
     "tslib": "^2.8.1",
-    "typescript": "^5.7.2",
-    "typescript-eslint": "^8.18.2"
+    "typescript": "^5.7.3",
+    "typescript-eslint": "^8.19.1"
   },
   "dependencies": {
     "@lezer/lr": "^1.4.2",

--- a/test/interpreter-spec.js
+++ b/test/interpreter-spec.js
@@ -316,6 +316,10 @@ describe('interpreter', function() {
         'b': 10
       });
 
+      expr('for i in numbers return i * 10', [ 10, 20 ], {
+        'numbers': [ 1, 2 ]
+      });
+
       expr('for condition in [ > 5, [1..3], 5 ] return 6 in condition', [ true, false, false ]);
 
       expr('for i in days in weekend return if i = "sunday" then true else false', [ false, true ], { 'days in weekend': [ 'saturday', 'sunday' ] });
@@ -328,7 +332,19 @@ describe('interpreter', function() {
 
       expr('for a in 1 return a', null);
 
-      exprSkip('for x in [ [1,2], [3,4] ], y in x return y', [ 1, 2, 3, 4 ]);
+      expr('for x in [ [1,2], [3,4] ], y in x return y', [ 1, 2, 3, 4 ]);
+      expr('for x in [ [ a, b ], c ], y in x, z in y return z', [ 1, 2, 3, 4, 5, 6, 7, 8 ], {
+        a: [ 1, 2 ],
+        b: [ 3, 4 ],
+        c: [ [ 5, 6 ], [ 7,8 ] ]
+      });
+      expr('for x in [ [ i + 1, i + 2 ], [ i + 3, i + 4] ], y in x return y', [ 1, 2, 3, 4 ], {
+        i: 0
+      });
+
+      expr('for x in [ 1 ], y in [x + 1] return y', [ 2 ]);
+
+      expr('for x in [ 1, null ], y in [ x + 1 ] return y', [ 2, null ]);
 
       exprSkip('for i in [2..1] return i', null);
 
@@ -368,6 +384,9 @@ describe('interpreter', function() {
         ]
       });
 
+      expr('every x in [ [1, 2], [3, 4] ], y in x satisfies y < 5', true);
+      expr('every x in [ [1, 2], [3, 4] ], y in x satisfies y > 3', false);
+
       expr('every e in [0] satisfies e = 0', true);
 
       expr('every e in [2] satisfies e = b * 2', true, {
@@ -391,6 +410,9 @@ describe('interpreter', function() {
           20
         ]
       });
+
+      expr('some x in [ [1, 2], [3, 4] ], y in x satisfies y > 5', false);
+      expr('some x in [ [1, 2], [3, 4] ], y in x satisfies y > 3', true);
 
       expr('every e in null satisfies e != 2', null);
 

--- a/test/reporters/tck.cjs
+++ b/test/reporters/tck.cjs
@@ -1,9 +1,9 @@
 /* eslint @typescript-eslint/no-require-imports: off */
 
 const { inherits } = require('node:util');
+const { readFileSync, writeFileSync } = require('node:fs');
 
 const Mocha = require('mocha');
-const fs = require('node:fs');
 
 const SpecReporter = Mocha.reporters.Spec;
 
@@ -107,7 +107,7 @@ function TckReporter(runner, options) {
 
     const oldResults = (function() {
       try {
-        return JSON.parse(fs.readFileSync(resultsJSONPath, 'utf8'));
+        return JSON.parse(readFileSync(resultsJSONPath, 'utf8'));
       } catch (e) {
         console.warn('could not read tck-results.json', e);
 
@@ -122,8 +122,8 @@ function TckReporter(runner, options) {
     if (process.env.DRY_RUN === 'false') {
       console.log('INFO: Writing test results.');
 
-      fs.writeFileSync(resultsImgPath, resultsSvg, 'utf8');
-      fs.writeFileSync(resultsJSONPath, JSON.stringify(results, null, 2), 'utf8');
+      writeFileSync(resultsImgPath, resultsSvg, 'utf8');
+      writeFileSync(resultsJSONPath, JSON.stringify(results, null, 2), 'utf8');
     } else {
 
       // indicate failure if test failures != expected failures

--- a/test/reporters/tck.cjs
+++ b/test/reporters/tck.cjs
@@ -127,7 +127,7 @@ function TckReporter(runner, options) {
     } else {
 
       // indicate failure if test failures != expected failures
-      if (oldResults.failures < results.failures) {
+      if (oldResults.failures !== results.failures) {
         console.log();
         console.log('INFO: Execute with DRY_RUN=false to update TCK test snapshots');
 


### PR DESCRIPTION
The [DMN spec](https://www.omg.org/spec/DMN/1.6/Beta1/PDF) / TCK mandates that the following works, i.e. you're able to consume prior context within an `InExpression`:

```
for x in [ [1,2], [3,4] ], y in x return y = [ 1, 2, 3, 4 ]
```

Conversely, the following must work, too:

```
some x in [ [1, 2], [3, 4] ], y in x satisfies y > 3 = true
every x in [ [1, 2], [3, 4] ], y in x satisfies y > 3 = false
```

This PR implements this feature.