### PR TITLE
ci: run update TCK action on `main` branch only

### DIFF
--- a/.github/workflows/DMN_TCK.yml
+++ b/.github/workflows/DMN_TCK.yml
@@ -1,7 +1,5 @@
 name: DMN_TCK
 on:
-  schedule:
-    - cron: '* 1 * * *'
   push:
   pull_request:
 
@@ -30,29 +28,3 @@ jobs:
       run: npm run tck
       env:
         TCK_DIR: tmp/dmn-tck
-
-  Propose_TCK_Update:
-    runs-on: ubuntu-latest
-    if: ${{ failure() }}
-
-    needs: Build
-
-    permissions:
-      contents: read
-      issues: write
-
-    steps:
-    - name: Update TCK results
-      run: npm run tck
-      env:
-        TCK_DIR: tmp/dmn-tck
-        DRY_RUN: false
-    - name: Propose update to TCK results
-      uses: peter-evans/create-pull-request@v7
-      with:
-        commit-message: |
-          test(tck): update results
-        branch: update-dmn-tck-status
-        title: Update DMN_TCK test results
-        body: |
-          Updating DMN_TCK results after test failure in [this action](https://github.com/nikku/feelin/actions/runs/${{ github.run_id }}).

--- a/.github/workflows/DMN_TCK_UPDATE.yml
+++ b/.github/workflows/DMN_TCK_UPDATE.yml
@@ -1,0 +1,44 @@
+name: DMN_TCK_UPDATE
+on:
+  schedule:
+    - cron: '* 1 * * *'
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v5
+    - name: Checkout TCK repo
+      uses: actions/checkout@v5
+      with:
+        repository: dmn-tck/tck
+        path: tmp/dmn-tck
+    - name: Use Node.js
+      uses: actions/setup-node@v5
+      with:
+        node-version: 20
+        cache: 'npm'
+    - name: Install dependencies
+      run: npm ci
+    - name: Build
+      run: npm run build
+    - name: Update TCK results
+      run: npm run tck
+      env:
+        TCK_DIR: tmp/dmn-tck
+        DRY_RUN: false
+    - name: Propose update to TCK results
+      uses: peter-evans/create-pull-request@v7
+      with:
+        commit-message: |
+          test(tck): update results
+        branch: update-dmn-tck-status
+        title: Update DMN_TCK test results
+        body: |
+          Updating DMN_TCK results after test failure in [this action](https://github.com/nikku/feelin/actions/runs/${{ github.run_id }}).


### PR DESCRIPTION
Ensure we don't run TCK update on push or pulls, but only periodically (one a day).