### PR TITLE
feat!: drop CJS distribution

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -83,5 +83,13 @@ export default [
       '@typescript-eslint/no-unused-expressions': 'off'
     },
     files: files.test
+  },
+  {
+    rules: {
+      '@typescript-eslint/no-require-imports': 'off'
+    },
+    files: [
+      '**/*.cjs'
+    ]
   }
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "typescript-eslint": "^8.48.0"
       },
       "engines": {
-        "node": "*"
+        "node": ">= 20.12.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,12 @@
   "author": "Nico Rehwaldt <git_nikku@nixis.de>",
   "license": "MIT",
   "type": "module",
-  "main": "dist/index.cjs",
-  "module": "dist/index.esm.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./package.json": "./package.json"
+  },
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^12.3.0",
@@ -39,7 +41,7 @@
     "url": "https://github.com/nikku/feelin"
   },
   "engines": {
-    "node": "*"
+    "node": ">= 20.12.0"
   },
   "sideEffects": false,
   "scripts": {
@@ -51,7 +53,7 @@
     "dev": "run-p *:dev",
     "generate-typings": "tsc --emitDeclarationOnly --declaration --outDir dist",
     "prepare": "run-s build generate-typings",
-    "test": "mocha -r source-map-support/register test/*-spec.js",
+    "test": "mocha -r source-map-support/register test/*-spec.js test/*-spec.cjs",
     "test:dev": "chokidar '{dist,test}/**/*.js' -c 'npm test'",
     "tck": "run-s tck:extract tck:test",
     "tck:extract": "node tasks/extract-tck-tests.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,12 +14,7 @@ export default [
     input: srcEntry,
     output: [
       {
-        file: pkg.main,
-        format: 'cjs',
-        sourcemap: true
-      },
-      {
-        file: pkg.module,
+        file: pkg.exports['.'],
         format: 'es',
         sourcemap: true
       }

--- a/test/builtins-spec.js
+++ b/test/builtins-spec.js
@@ -6,7 +6,7 @@ import {
 
 import {
   evaluate
-} from '../dist/index.esm.js';
+} from 'feelin';
 
 import {
   evaluate as evaluateMinified

--- a/test/interpreter-perf-spec.js
+++ b/test/interpreter-perf-spec.js
@@ -4,7 +4,7 @@ import {
 
 import {
   evaluate
-} from '../dist/index.esm.js';
+} from 'feelin';
 
 
 describe('interpreter', function() {

--- a/test/interpreter-spec.cjs
+++ b/test/interpreter-spec.cjs
@@ -1,0 +1,28 @@
+const { expect } = require('./helpers.js');
+
+const {
+  unaryTest,
+  evaluate
+} = require('feelin');
+
+
+describe('interpreter', function() {
+
+  describe('cjs', function() {
+
+    it('should evaluate', function() {
+
+      // then
+      expect(evaluate('1 < 2')).to.be.true;
+    });
+
+
+    it('should unaryTest', function() {
+
+      // then
+      expect(unaryTest('< 2', { '?': 1 })).to.be.true;
+    });
+
+  });
+
+});

--- a/test/interpreter-spec.js
+++ b/test/interpreter-spec.js
@@ -7,7 +7,7 @@ import {
   evaluate,
   date,
   duration
-} from '../dist/index.esm.js';
+} from 'feelin';
 
 
 describe('interpreter', function() {

--- a/test/tck/tck-spec.js
+++ b/test/tck/tck-spec.js
@@ -9,7 +9,7 @@ import {
 
 import {
   evaluate
-} from '../../dist/index.esm.js';
+} from 'feelin';
 
 
 const NOT_IMPLEMENTED = {};


### PR DESCRIPTION
### Changes

This package is now ESM only, and may be imported by Node >= 20.12.0.

BREAKING CHANGE: Require Node >= 20 for consuming this module from CJS.
