### PR TITLE
Explicitly declare dependency to `min-dash`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@lezer/lr": "^1.4.3",
         "lezer-feel": "^1.9.0",
-        "luxon": "^3.7.2"
+        "luxon": "^3.7.2",
+        "min-dash": "^4.2.3"
       },
       "devDependencies": {
         "@rollup/plugin-terser": "^0.4.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "dependencies": {
     "@lezer/lr": "^1.4.3",
     "lezer-feel": "^1.9.0",
-    "luxon": "^3.7.2"
+    "luxon": "^3.7.2",
+    "min-dash": "^4.2.3"
   },
   "repository": {
     "type": "git",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,7 +10,8 @@ const input = pkg.source;
 const external = [
   'lezer',
   'lezer-feel',
-  'luxon'
+  'luxon',
+  'min-dash'
 ];
 
 export default [


### PR DESCRIPTION
### Changes

The dependency `min-dash` was previously transitively pulled in; now it is explicitly declared.