### PR TITLE
Consolidate FEEL type surface

### DIFF
--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -18,10 +18,13 @@ import {
 } from './range.js';
 
 import {
+  parseParameterNames
+} from './function.js';
+
+import {
   getFromContext,
   isNotImplemented,
-  notImplemented,
-  parseParameterNames
+  notImplemented
 } from './utils.js';
 
 import {

--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -1,7 +1,6 @@
 import {
   isType,
   equals,
-  FeelRange,
   isString,
   isNumber,
   getType,
@@ -11,6 +10,12 @@ import {
   isDateTime,
   isDuration
 } from './types.js';
+
+import {
+  before,
+  meets,
+  includes as includesRange
+} from './range.js';
 
 import {
   getFromContext,
@@ -728,11 +733,11 @@ const builtins = {
   }, [ 'any', 'any' ], [ 'a', 'b' ]),
 
   'meets': fn(function(range1, range2) {
-    return meetsRange(range1, range2);
+    return meets(range1, range2);
   }, [ 'range', 'range' ], [ 'range1', 'range2' ]),
 
   'met by': fn(function(range1, range2) {
-    return meetsRange(range2, range1);
+    return meets(range2, range1);
   }, [ 'range', 'range' ], [ 'range1', 'range2' ]),
 
   'overlaps': fn(function(range1, range2) {
@@ -1040,96 +1045,6 @@ function fn(fnDefinition, argDefinitions, parameterNames = null) {
   wrappedFn.$args = parameterNames;
 
   return wrappedFn;
-}
-
-/**
- * @param {FeelRange} a
- * @param {FeelRange} b
- */
-function meetsRange(a, b) {
-  return [
-    (a.end === b.start),
-    (a['end included'] === true),
-    (b['start included'] === true)
-  ].every(v => v);
-}
-
-/**
- * @param {FeelRange|number} a
- * @param {FeelRange|number} b
- */
-function before(a, b) {
-  if (a instanceof FeelRange && b instanceof FeelRange) {
-    return (
-      a.end < b.start || (
-        !a['end included'] || !b['start included']
-      ) && a.end == b.start
-    );
-  }
-
-  if (a instanceof FeelRange) {
-    return (
-      a.end < b || (
-        !a['end included'] && a.end === b
-      )
-    );
-  }
-
-  if (b instanceof FeelRange) {
-    return (
-      b.start > a || (
-        !b['start included'] && b.start === a
-      )
-    );
-  }
-
-  return a < b;
-}
-
-/**
- * @param {FeelRange} container - The range that should contain the other value
- * @param {FeelRange|number} value - The range or point to check if contained
- */
-function includesRange(container, value) {
-  if (!(container instanceof FeelRange)) {
-    return false;
-  }
-
-  // Range includes another range
-  if (value instanceof FeelRange) {
-    const startOk = (
-      container.start < value.start ||
-      (
-        container.start === value.start &&
-        (container['start included'] || !value['start included'])
-      )
-    );
-
-    // Check end boundary: container.end >= value.end
-    const endOk = (
-      container.end > value.end ||
-      (
-        container.end === value.end &&
-        (container['end included'] || !value['end included'])
-      )
-    );
-
-    return startOk && endOk;
-  }
-
-  // Range includes a point
-  // Check if point is within [start, end] considering inclusive/exclusive
-  const afterStart = (
-    value > container.start ||
-    (value === container.start && container['start included'])
-  );
-
-  const beforeEnd = (
-    value < container.end ||
-    (value === container.end && container['end included'])
-  );
-
-  return afterStart && beforeEnd;
 }
 
 function sum(list) {

--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -1,7 +1,7 @@
 import {
   isType,
   equals,
-  Range,
+  FeelRange,
   isString,
   isNumber,
   getType,
@@ -1043,8 +1043,8 @@ function fn(fnDefinition, argDefinitions, parameterNames = null) {
 }
 
 /**
- * @param {Range} a
- * @param {Range} b
+ * @param {FeelRange} a
+ * @param {FeelRange} b
  */
 function meetsRange(a, b) {
   return [
@@ -1055,11 +1055,11 @@ function meetsRange(a, b) {
 }
 
 /**
- * @param {Range|number} a
- * @param {Range|number} b
+ * @param {FeelRange|number} a
+ * @param {FeelRange|number} b
  */
 function before(a, b) {
-  if (a instanceof Range && b instanceof Range) {
+  if (a instanceof FeelRange && b instanceof FeelRange) {
     return (
       a.end < b.start || (
         !a['end included'] || !b['start included']
@@ -1067,7 +1067,7 @@ function before(a, b) {
     );
   }
 
-  if (a instanceof Range) {
+  if (a instanceof FeelRange) {
     return (
       a.end < b || (
         !a['end included'] && a.end === b
@@ -1075,7 +1075,7 @@ function before(a, b) {
     );
   }
 
-  if (b instanceof Range) {
+  if (b instanceof FeelRange) {
     return (
       b.start > a || (
         !b['start included'] && b.start === a
@@ -1087,16 +1087,16 @@ function before(a, b) {
 }
 
 /**
- * @param {Range} container - The range that should contain the other value
- * @param {Range|number} value - The range or point to check if contained
+ * @param {FeelRange} container - The range that should contain the other value
+ * @param {FeelRange|number} value - The range or point to check if contained
  */
 function includesRange(container, value) {
-  if (!(container instanceof Range)) {
+  if (!(container instanceof FeelRange)) {
     return false;
   }
 
   // Range includes another range
-  if (value instanceof Range) {
+  if (value instanceof FeelRange) {
     const startOk = (
       container.start < value.start ||
       (

--- a/src/function.ts
+++ b/src/function.ts
@@ -1,0 +1,161 @@
+import { isArray } from './types.js';
+
+import { isRange } from './range.js';
+
+/**
+ * This module is the single place in the code base that deals with FEEL
+ * <function> values.
+ *
+ * A {@link FeelFunction} is pure data (its wrapped implementation and the
+ * names of its parameters) plus the {@link FeelFunction#invoke} behavior
+ * that binds positional or named arguments to those parameters. Coercion of
+ * arbitrary values into functions — including the range-as-membership-test
+ * shortcut — is centralized in {@link wrapFunction}, and the parameter names
+ * of a plain JS function are recovered through {@link parseParameterNames}.
+ */
+
+/**
+ * Sentinel returned by {@link FeelFunction#invoke} when the provided
+ * arguments do not match the function's parameters.
+ */
+export const FUNCTION_PARAMETER_MISSMATCH = {};
+
+
+export class FeelFunction {
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fn: (...args) => any;
+  parameterNames: string[];
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  constructor(fn: (...args) => any, parameterNames: string[]) {
+
+    this.fn = fn;
+    this.parameterNames = parameterNames;
+
+    // the wrapped implementation is an internal detail; keep it
+    // non-enumerable so serialization and structural comparison rely on
+    // the public parameter names rather than the opaque closure
+    Object.defineProperty(this, 'fn', { enumerable: false });
+  }
+
+  invoke(contextOrArgs) {
+
+    let params;
+
+    if (isArray(contextOrArgs)) {
+      params = contextOrArgs;
+
+      // reject
+      if (params.length > this.parameterNames.length) {
+
+        const lastParam = this.parameterNames[this.parameterNames.length - 1];
+
+        // strictly check for parameter count provided
+        // for non var-args functions
+        if (!lastParam || !lastParam.startsWith('...')) {
+          return FUNCTION_PARAMETER_MISSMATCH;
+        }
+      }
+    } else {
+
+      // strictly check for required parameter names,
+      // and fail on wrong parameter name
+      if (Object.keys(contextOrArgs).some(
+        key => !this.parameterNames.includes(key) && !this.parameterNames.includes(`...${key}`)
+      )) {
+        return FUNCTION_PARAMETER_MISSMATCH;
+      }
+
+      params = this.parameterNames.reduce((params, name) => {
+
+        if (name.startsWith('...')) {
+          name = name.slice(3);
+
+          const value = contextOrArgs[name];
+
+          if (!value) {
+            return params;
+          } else {
+
+            // ensure that single arg provided for var args named
+            // parameter is wrapped in a list
+            return [ ...params, ...(isArray(value) ? value : [ value ]) ];
+          }
+        }
+
+        return [ ...params, contextOrArgs[name] ];
+      }, []);
+    }
+
+    return this.fn.call(null, ...params);
+  }
+}
+
+/**
+ * Whether the value is a FEEL <function>.
+ */
+export function isFunction(obj) : obj is FeelFunction {
+  return obj instanceof FeelFunction;
+}
+
+/**
+ * Recover the parameter names of a plain JS function, either from an
+ * explicit `$args` annotation or by parsing its source.
+ */
+export function parseParameterNames(fn) {
+
+  if (Array.isArray(fn.$args)) {
+    return fn.$args;
+  }
+
+  const code = fn.toString();
+
+  const match = /^(?:[^(]*\s*)?\(([^)]+)?\)/.exec(code);
+
+  if (!match) {
+    throw new Error('failed to parse params: ' + code);
+  }
+
+  const [ _, params ] = match;
+
+  if (!params) {
+    return [];
+  }
+
+  return params.split(',').map(p => p.trim());
+}
+
+/**
+ * Coerce a value into a {@link FeelFunction}.
+ *
+ * Passes through existing functions, turns a {@link FeelRange} into a
+ * membership test and wraps a plain JS function (recovering its parameter
+ * names when not given). Returns `null` for anything that cannot be
+ * invoked.
+ *
+ * @param {Function} fn
+ * @param {string[]} [parameterNames]
+ *
+ * @return {FeelFunction}
+ */
+export function wrapFunction(fn, parameterNames = null) {
+
+  if (!fn) {
+    return null;
+  }
+
+  if (fn instanceof FeelFunction) {
+    return fn;
+  }
+
+  if (isRange(fn)) {
+    return new FeelFunction((value) => fn.includes(value), [ 'value' ]);
+  }
+
+  if (typeof fn !== 'function') {
+    return null;
+  }
+
+  return new FeelFunction(fn, parameterNames || parseParameterNames(fn));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ export * from './parser.js';
 export {
   FeelFunction,
   isFunction
-} from './types.js';
+} from './function.js';
 
 export {
   FeelRange,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,13 @@ export * from './interpreter.js';
 export * from './parser.js';
 
 export {
-  FeelFunction
+  FeelFunction,
+  isFunction
 } from './types.js';
 
 export {
-  FeelRange
+  FeelRange,
+  isRange
 } from './range.js';
 
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,11 @@ export * from './interpreter.js';
 export * from './parser.js';
 
 export {
+  FeelRange,
+  FeelFunction
+} from './types.js';
+
+export {
   FeelDate,
   FeelTime,
   FeelDateTime,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,9 +3,12 @@ export * from './interpreter.js';
 export * from './parser.js';
 
 export {
-  FeelRange,
   FeelFunction
 } from './types.js';
+
+export {
+  FeelRange
+} from './range.js';
 
 export {
   FeelDate,

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -17,7 +17,7 @@ import {
 } from './types.js';
 
 import {
-  FeelRange,
+  isRange,
   createRange
 } from './range.js';
 
@@ -1061,7 +1061,7 @@ function evalNode(node: Node, args: any[], interpreterContext: InterpreterContex
           result = result(el);
         }
 
-        if (result instanceof FeelRange) {
+        if (isRange(result)) {
           result = result.includes(el);
         }
 
@@ -1182,7 +1182,7 @@ function compareValue(test, value) {
     return test(value);
   }
 
-  if (test instanceof FeelRange) {
+  if (isRange(test)) {
     return test.includes(value);
   }
 
@@ -1238,7 +1238,7 @@ function wrapFunction(fn, parameterNames = null) {
     return fn;
   }
 
-  if (fn instanceof FeelRange) {
+  if (isRange(fn)) {
     return new FeelFunction((value) => fn.includes(value), [ 'value' ]);
   }
 

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -5,8 +5,8 @@ import { builtins } from './builtins.js';
 import { has } from 'min-dash';
 
 import {
-  Range,
-  FunctionWrapper,
+  FeelRange,
+  FeelFunction,
   FUNCTION_PARAMETER_MISSMATCH,
   equals,
   isArray,
@@ -1058,7 +1058,7 @@ function evalNode(node: Node, args: any[], interpreterContext: InterpreterContex
           result = result(el);
         }
 
-        if (result instanceof Range) {
+        if (result instanceof FeelRange) {
           result = result.includes(el);
         }
 
@@ -1179,7 +1179,7 @@ function compareValue(test, value) {
     return test(value);
   }
 
-  if (test instanceof Range) {
+  if (test instanceof FeelRange) {
     return test.includes(value);
   }
 
@@ -1198,7 +1198,7 @@ function isTyped(type, values) {
   );
 }
 
-const nullRange = new Range({
+const nullRange = new FeelRange({
   start: null,
   end: null,
   'start included': false,
@@ -1211,7 +1211,7 @@ const nullRange = new Range({
   }
 });
 
-function createRange(start, end, startIncluded = true, endIncluded = true) : Range {
+function createRange(start, end, startIncluded = true, endIncluded = true) : FeelRange {
 
   if (isTyped('string', [ start, end ])) {
     return createStringRange(start, end, startIncluded, endIncluded);
@@ -1366,7 +1366,7 @@ function createStringRange(start, end, startIncluded = true, endIncluded = true)
   const map = values ? valuesMap(values) : noopMap();
   const includes = values ? valuesIncludes(values) : anyIncludes(start, end, startIncluded, endIncluded);
 
-  return new Range({
+  return new FeelRange({
     start,
     end,
     'start included': startIncluded,
@@ -1380,7 +1380,7 @@ function createNumberRange(start, end, startIncluded, endIncluded) {
   const map = start !== null && end !== null ? numberMap(start, end, startIncluded, endIncluded) : noopMap();
   const includes = anyIncludes(start, end, startIncluded, endIncluded);
 
-  return new Range({
+  return new FeelRange({
     start,
     end,
     'start included': startIncluded,
@@ -1403,7 +1403,7 @@ function createDurationRange(start, end, startIncluded, endIncluded) {
   const map = noopMap();
   const includes = anyIncludes(toMillis(start), toMillis(end), startIncluded, endIncluded, toMillis);
 
-  return new Range({
+  return new FeelRange({
     start,
     end,
     'start included': startIncluded,
@@ -1422,7 +1422,7 @@ function createDateTimeRange(start, end, startIncluded, endIncluded) {
   const map = noopMap();
   const includes = anyIncludes(toMillis(start), toMillis(end), startIncluded, endIncluded, toMillis);
 
-  return new Range({
+  return new FeelRange({
     start,
     end,
     'start included': startIncluded,
@@ -1469,7 +1469,7 @@ function isTruthy(obj) {
  * @param {Function} fn
  * @param {string[]} [parameterNames]
  *
- * @return {FunctionWrapper}
+ * @return {FeelFunction}
  */
 function wrapFunction(fn, parameterNames = null) {
 
@@ -1477,19 +1477,19 @@ function wrapFunction(fn, parameterNames = null) {
     return null;
   }
 
-  if (fn instanceof FunctionWrapper) {
+  if (fn instanceof FeelFunction) {
     return fn;
   }
 
-  if (fn instanceof Range) {
-    return new FunctionWrapper((value) => fn.includes(value), [ 'value' ]);
+  if (fn instanceof FeelRange) {
+    return new FeelFunction((value) => fn.includes(value), [ 'value' ]);
   }
 
   if (typeof fn !== 'function') {
     return null;
   }
 
-  return new FunctionWrapper(fn, parameterNames || parseParameterNames(fn));
+  return new FeelFunction(fn, parameterNames || parseParameterNames(fn));
 }
 
 function parseString(str: string) {

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -5,8 +5,6 @@ import { builtins } from './builtins.js';
 import { has } from 'min-dash';
 
 import {
-  FeelFunction,
-  FUNCTION_PARAMETER_MISSMATCH,
   equals,
   isArray,
   getType,
@@ -22,8 +20,12 @@ import {
 } from './range.js';
 
 import {
+  FUNCTION_PARAMETER_MISSMATCH,
+  wrapFunction
+} from './function.js';
+
+import {
   notImplemented,
-  parseParameterNames,
   getFromContext
 } from './utils.js';
 
@@ -1220,33 +1222,6 @@ function tag<Z, T extends ContextFn<Z>>(fn: T, type: string) : T & TaggedFn {
 
 function isTruthy(obj) {
   return obj !== false && obj !== null;
-}
-
-/**
- * @param {Function} fn
- * @param {string[]} [parameterNames]
- *
- * @return {FeelFunction}
- */
-function wrapFunction(fn, parameterNames = null) {
-
-  if (!fn) {
-    return null;
-  }
-
-  if (fn instanceof FeelFunction) {
-    return fn;
-  }
-
-  if (isRange(fn)) {
-    return new FeelFunction((value) => fn.includes(value), [ 'value' ]);
-  }
-
-  if (typeof fn !== 'function') {
-    return null;
-  }
-
-  return new FeelFunction(fn, parameterNames || parseParameterNames(fn));
 }
 
 function parseString(str: string) {

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -5,7 +5,6 @@ import { builtins } from './builtins.js';
 import { has } from 'min-dash';
 
 import {
-  FeelRange,
   FeelFunction,
   FUNCTION_PARAMETER_MISSMATCH,
   equals,
@@ -16,6 +15,11 @@ import {
   isContext,
   isBoolean
 } from './types.js';
+
+import {
+  FeelRange,
+  createRange
+} from './range.js';
 
 import {
   notImplemented,
@@ -29,7 +33,6 @@ import {
 } from './parser.js';
 
 import {
-  toComparable,
   isTemporal,
   addDuration,
   subtractTemporals,
@@ -1184,252 +1187,6 @@ function compareValue(test, value) {
   }
 
   return equals(test, value);
-}
-
-
-const chars = Array.from(
-  'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
-);
-
-function isTyped(type, values) {
-  return (
-    values.some(e => getType(e) === type) &&
-    values.every(e => e === null || getType(e) === type)
-  );
-}
-
-const nullRange = new FeelRange({
-  start: null,
-  end: null,
-  'start included': false,
-  'end included': false,
-  map() {
-    return [];
-  },
-  includes() {
-    return null;
-  }
-});
-
-function createRange(start, end, startIncluded = true, endIncluded = true) : FeelRange {
-
-  if (isTyped('string', [ start, end ])) {
-    return createStringRange(start, end, startIncluded, endIncluded);
-  }
-
-  if (isTyped('number', [ start, end ])) {
-    return createNumberRange(start, end, startIncluded, endIncluded);
-  }
-
-  if (isTyped('duration', [ start, end ])) {
-    return createDurationRange(start, end, startIncluded, endIncluded);
-  }
-
-  if (isTyped('time', [ start, end ])) {
-    return createDateTimeRange(start, end, startIncluded, endIncluded);
-  }
-
-  if (isTyped('date time', [ start, end ])) {
-    return createDateTimeRange(start, end, startIncluded, endIncluded);
-  }
-
-  if (isTyped('date', [ start, end ])) {
-    return createDateTimeRange(start, end, startIncluded, endIncluded);
-  }
-
-  if (start === null && end === null) {
-    return nullRange;
-  }
-
-  throw new Error(`unsupported range: ${start}..${end}`);
-}
-
-function noopMap() {
-  return () => {
-    throw new Error('unsupported range operation: map');
-  };
-}
-
-function valuesMap(values) {
-  return (fn) => values.map(fn);
-}
-
-function valuesIncludes(values) {
-  return (value) => values.includes(value);
-}
-
-function numberMap(start, end, startIncluded, endIncluded) {
-
-  const direction = start > end ? -1 : 1;
-
-  return (fn) => {
-
-    const result = [];
-
-    for (let i = start;; i += direction) {
-
-      if (i === 0 && !startIncluded) {
-        continue;
-      }
-
-      if (i === end && !endIncluded) {
-        break;
-      }
-
-      result.push(fn(i));
-
-      if (i === end) {
-        break;
-      }
-    }
-
-    return result;
-  };
-}
-
-function includesStart(n, inclusive) {
-
-  if (inclusive) {
-    return (value) => n <= value;
-  } else {
-    return (value) => n < value;
-  }
-}
-
-function includesEnd(n, inclusive) {
-
-  if (inclusive) {
-    return (value) => n >= value;
-  } else {
-    return (value) => n > value;
-  }
-}
-
-function anyIncludes(start, end, startIncluded, endIncluded, conversion = (v) => v) {
-
-  let tests = [];
-
-  if (start === null && end === null) {
-    return () => null;
-  }
-
-  if (start !== null && end !== null) {
-    if (start > end) {
-      tests = [
-        includesStart(end, endIncluded),
-        includesEnd(start, startIncluded)
-      ];
-    } else {
-      tests = [
-        includesStart(start, startIncluded),
-        includesEnd(end, endIncluded)
-      ];
-    }
-  } else if (end !== null) {
-    tests = [
-      includesEnd(end, endIncluded)
-    ];
-  } else if (start !== null) {
-    tests = [
-      includesStart(start, startIncluded)
-    ];
-  }
-
-  return (value) => value === null ? null : tests.every(t => t(conversion(value)));
-}
-
-function createStringRange(start, end, startIncluded = true, endIncluded = true) {
-
-  const singleStartChar = start !== null && chars.includes(start);
-  const singleEndChar = end !== null && chars.includes(end);
-
-  let values;
-
-  if (singleStartChar && singleEndChar) {
-
-    let startIdx = chars.indexOf(start);
-    let endIdx = chars.indexOf(end);
-
-    const direction = startIdx > endIdx ? -1 : 1;
-
-    if (startIncluded === false) {
-      startIdx += direction;
-    }
-
-    if (endIncluded === false) {
-      endIdx -= direction;
-    }
-
-    values = chars.slice(startIdx, endIdx + 1);
-  }
-
-  const map = values ? valuesMap(values) : noopMap();
-  const includes = values ? valuesIncludes(values) : anyIncludes(start, end, startIncluded, endIncluded);
-
-  return new FeelRange({
-    start,
-    end,
-    'start included': startIncluded,
-    'end included': endIncluded,
-    map,
-    includes
-  });
-}
-
-function createNumberRange(start, end, startIncluded, endIncluded) {
-  const map = start !== null && end !== null ? numberMap(start, end, startIncluded, endIncluded) : noopMap();
-  const includes = anyIncludes(start, end, startIncluded, endIncluded);
-
-  return new FeelRange({
-    start,
-    end,
-    'start included': startIncluded,
-    'end included': endIncluded,
-    map,
-    includes
-  });
-}
-
-/**
- * @param {FeelDuration} start
- * @param {FeelDuration} end
- * @param {boolean} startIncluded
- * @param {boolean} endIncluded
- */
-function createDurationRange(start, end, startIncluded, endIncluded) {
-
-  const toMillis = (d) => d ? toComparable(d) : null;
-
-  const map = noopMap();
-  const includes = anyIncludes(toMillis(start), toMillis(end), startIncluded, endIncluded, toMillis);
-
-  return new FeelRange({
-    start,
-    end,
-    'start included': startIncluded,
-    'end included': endIncluded,
-    map,
-    includes
-  });
-
-}
-
-
-function createDateTimeRange(start, end, startIncluded, endIncluded) {
-
-  const toMillis = (d) => d ? toComparable(d) : null;
-
-  const map = noopMap();
-  const includes = anyIncludes(toMillis(start), toMillis(end), startIncluded, endIncluded, toMillis);
-
-  return new FeelRange({
-    start,
-    end,
-    'start included': startIncluded,
-    'end included': endIncluded,
-    map,
-    includes
-  });
 }
 
 

--- a/src/range.ts
+++ b/src/range.ts
@@ -1,0 +1,372 @@
+import { toComparable } from './temporal.js';
+
+import { getType } from './types.js';
+
+/**
+ * This module is the single place in the code base that deals with FEEL
+ * <range> values.
+ *
+ * A {@link FeelRange} is pure data (its bounds and their inclusion) plus a
+ * non-enumerable {@link FeelRange#valueType} that records the FEEL type of
+ * its elements (e.g. `number`, `date`). All behavior — membership
+ * ({@link FeelRange#includes}), iteration ({@link FeelRange#map}) and the
+ * range relation functions ({@link before}, {@link meets},
+ * {@link includes}) — is derived from that data through a single
+ * comparator ({@link cmp}). Because the comparator routes temporal values
+ * through {@link toComparable}, ranges of dates, times and durations
+ * compare correctly, just like ranges of numbers and strings.
+ */
+
+/**
+ * A value that may appear as a range bound: a number, a string or a FEEL
+ * temporal value (date, time, date time or duration).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type RangeValue = any;
+
+export type FeelRangeProps = {
+  'start included': boolean;
+  'end included': boolean;
+  start: RangeValue | null;
+  end: RangeValue | null;
+  valueType: string | null;
+};
+
+/**
+ * A FEEL <range> (e.g. `[1..10]`, `(date("2020-01-01")..date("2020-12-31")]`).
+ *
+ * The FEEL-visible properties are `start`, `end`, `start included` and
+ * `end included`. The element type is tracked separately (and
+ * non-enumerably) as {@link valueType} so it does not leak into context
+ * spreads or path access.
+ */
+export class FeelRange {
+
+  'start included': boolean;
+  'end included': boolean;
+  start: RangeValue | null;
+  end: RangeValue | null;
+
+  /**
+   * @internal FEEL type of the range elements, `null` for the empty range
+   */
+  valueType: string | null;
+
+  constructor(props: FeelRangeProps) {
+    Object.assign(this, props);
+
+    // the element type is identity, not a FEEL-visible property; keep it
+    // non-enumerable so it does not leak into context spreads / path access
+    Object.defineProperty(this, 'valueType', { enumerable: false });
+  }
+
+  /**
+   * Whether the range includes the given point or range. Returns `null`
+   * for the empty range or a `null` probe.
+   */
+  includes(value: RangeValue | null) : boolean | null {
+    return rangeIncludes(this, value);
+  }
+
+  /**
+   * Enumerate the range, applying `fn` to each element. Only defined for
+   * closed number ranges and single-character string ranges.
+   */
+  map<T>(fn: (val: RangeValue) => T) : T[] {
+    return rangeMap(this, fn);
+  }
+
+  toString() : string {
+    const startBracket = this['start included'] ? '[' : '(';
+    const endBracket = this['end included'] ? ']' : ')';
+
+    return `${startBracket}${this.start}..${this.end}${endBracket}`;
+  }
+}
+
+
+// comparator ////////////////////////////////////////////////////////
+
+/**
+ * Reduce a range value to something orderable: temporal values become
+ * their comparable number, everything else (numbers, strings) is used
+ * as-is.
+ */
+function comparable(value: RangeValue) : RangeValue {
+  const c = toComparable(value);
+
+  return c === null ? value : c;
+}
+
+/**
+ * Compare two same-typed, non-null range values. Returns `-1`, `0` or
+ * `1`.
+ */
+function cmp(a: RangeValue, b: RangeValue) : number {
+  const ca = comparable(a);
+  const cb = comparable(b);
+
+  if (ca < cb) {
+    return -1;
+  }
+
+  if (ca > cb) {
+    return 1;
+  }
+
+  return 0;
+}
+
+
+// membership ////////////////////////////////////////////////////////
+
+function afterStart(value, start, startIncluded) {
+  if (start === null) {
+    return true;
+  }
+
+  const c = cmp(value, start);
+
+  return startIncluded ? c >= 0 : c > 0;
+}
+
+function beforeEnd(value, end, endIncluded) {
+  if (end === null) {
+    return true;
+  }
+
+  const c = cmp(value, end);
+
+  return endIncluded ? c <= 0 : c < 0;
+}
+
+function rangeIncludes(range: FeelRange, value: RangeValue | null) : boolean | null {
+
+  let { start, end } = range;
+  let startIncluded = range['start included'];
+  let endIncluded = range['end included'];
+
+  // empty range
+  if (start === null && end === null) {
+    return null;
+  }
+
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (value instanceof FeelRange) {
+    return rangeIncludesRange(range, value);
+  }
+
+  // normalize a descending range (e.g. `[10..1]`) so bounds are ordered
+  if (start !== null && end !== null && cmp(start, end) > 0) {
+    [ start, end ] = [ end, start ];
+    [ startIncluded, endIncluded ] = [ endIncluded, startIncluded ];
+  }
+
+  return (
+    afterStart(value, start, startIncluded) &&
+    beforeEnd(value, end, endIncluded)
+  );
+}
+
+function rangeIncludesRange(container: FeelRange, value: FeelRange) : boolean {
+
+  const startOk = container.start === null || (
+    value.start !== null && (() => {
+      const c = cmp(container.start, value.start);
+
+      return c < 0 || (
+        c === 0 && (container['start included'] || !value['start included'])
+      );
+    })()
+  );
+
+  const endOk = container.end === null || (
+    value.end !== null && (() => {
+      const c = cmp(container.end, value.end);
+
+      return c > 0 || (
+        c === 0 && (container['end included'] || !value['end included'])
+      );
+    })()
+  );
+
+  return startOk && endOk;
+}
+
+
+// relations (used by built-in range functions) //////////////////////
+
+/**
+ * Whether `a` is (entirely) before `b`. Both operands may be a point or
+ * a {@link FeelRange}.
+ */
+export function before(a: RangeValue, b: RangeValue) : boolean {
+
+  if (a instanceof FeelRange && b instanceof FeelRange) {
+    const c = cmp(a.end, b.start);
+
+    return c < 0 || (
+      c === 0 && (!a['end included'] || !b['start included'])
+    );
+  }
+
+  if (a instanceof FeelRange) {
+    const c = cmp(a.end, b);
+
+    return c < 0 || (c === 0 && !a['end included']);
+  }
+
+  if (b instanceof FeelRange) {
+    const c = cmp(b.start, a);
+
+    return c > 0 || (c === 0 && !b['start included']);
+  }
+
+  return cmp(a, b) < 0;
+}
+
+/**
+ * Whether range `a` meets range `b`, i.e. `a` ends exactly where `b`
+ * starts, both inclusive.
+ */
+export function meets(a: FeelRange, b: FeelRange) : boolean {
+  return (
+    cmp(a.end, b.start) === 0 &&
+    a['end included'] === true &&
+    b['start included'] === true
+  );
+}
+
+/**
+ * Whether `range` includes the given point or range.
+ */
+export function includes(range: FeelRange, value: RangeValue) : boolean | null {
+
+  if (!(range instanceof FeelRange)) {
+    return false;
+  }
+
+  return rangeIncludes(range, value);
+}
+
+
+// iteration /////////////////////////////////////////////////////////
+
+const chars = Array.from(
+  'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+);
+
+function rangeMap<T>(range: FeelRange, fn: (val: RangeValue) => T) : T[] {
+
+  const { start, end, valueType } = range;
+
+  // empty range
+  if (start === null && end === null) {
+    return [];
+  }
+
+  if (valueType === 'number' && start !== null && end !== null) {
+    return numberRangeMap(start, end, range['start included'], range['end included'], fn);
+  }
+
+  if (valueType === 'string' && start !== null && end !== null) {
+    const values = charRangeValues(start, end, range['start included'], range['end included']);
+
+    if (values) {
+      return values.map(fn);
+    }
+  }
+
+  throw new Error('unsupported range operation: map');
+}
+
+function numberRangeMap<T>(start, end, startIncluded, endIncluded, fn: (val) => T) : T[] {
+
+  const direction = start > end ? -1 : 1;
+
+  const result: T[] = [];
+
+  for (let i = start;; i += direction) {
+
+    if (i === start && !startIncluded) {
+      continue;
+    }
+
+    if (i === end && !endIncluded) {
+      break;
+    }
+
+    result.push(fn(i));
+
+    if (i === end) {
+      break;
+    }
+  }
+
+  return result;
+}
+
+function charRangeValues(start, end, startIncluded, endIncluded) : string[] | null {
+
+  if (!chars.includes(start) || !chars.includes(end)) {
+    return null;
+  }
+
+  let startIdx = chars.indexOf(start);
+  let endIdx = chars.indexOf(end);
+
+  const direction = startIdx > endIdx ? -1 : 1;
+
+  if (startIncluded === false) {
+    startIdx += direction;
+  }
+
+  if (endIncluded === false) {
+    endIdx -= direction;
+  }
+
+  return chars.slice(
+    Math.min(startIdx, endIdx),
+    Math.max(startIdx, endIdx) + 1
+  );
+}
+
+
+// construction //////////////////////////////////////////////////////
+
+const RANGE_TYPES = [ 'string', 'number', 'duration', 'time', 'date time', 'date' ];
+
+function isTyped(type: string, values: RangeValue[]) : boolean {
+  return (
+    values.some(e => getType(e) === type) &&
+    values.every(e => e === null || getType(e) === type)
+  );
+}
+
+/**
+ * Create a {@link FeelRange} from its bounds, inferring the element type.
+ */
+export function createRange(
+    start: RangeValue | null,
+    end: RangeValue | null,
+    startIncluded = true,
+    endIncluded = true
+) : FeelRange {
+
+  const valueType = RANGE_TYPES.find(type => isTyped(type, [ start, end ])) ?? null;
+
+  if (valueType === null && !(start === null && end === null)) {
+    throw new Error(`unsupported range: ${start}..${end}`);
+  }
+
+  return new FeelRange({
+    start,
+    end,
+    'start included': startIncluded,
+    'end included': endIncluded,
+    valueType
+  });
+}

--- a/src/range.ts
+++ b/src/range.ts
@@ -84,6 +84,13 @@ export class FeelRange {
   }
 }
 
+/**
+ * Whether the value is a FEEL <range>.
+ */
+export function isRange(obj) : obj is FeelRange {
+  return obj instanceof FeelRange;
+}
+
 
 // comparator ////////////////////////////////////////////////////////
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,11 +80,11 @@ export function getType(e) {
     return 'date time';
   }
 
-  if (e instanceof Range) {
+  if (e instanceof FeelRange) {
     return 'range';
   }
 
-  if (e instanceof FunctionWrapper) {
+  if (e instanceof FeelFunction) {
     return 'function';
   }
 
@@ -129,7 +129,7 @@ export function typeCast(obj: any, type: string) {
   return null;
 }
 
-export type RangeProps = {
+export type FeelRangeProps = {
   'start included': boolean;
   'end included': boolean;
   start: string|number|null;
@@ -142,7 +142,7 @@ export type RangeProps = {
   includes: (val: any) => boolean;
 };
 
-export class Range {
+export class FeelRange {
 
   'start included': boolean;
   'end included': boolean;
@@ -155,7 +155,7 @@ export class Range {
 
   includes: (val) => boolean;
 
-  constructor(props: RangeProps) {
+  constructor(props: FeelRangeProps) {
     Object.assign(this, props);
   }
 }
@@ -267,7 +267,7 @@ export function equals(a, b, strict = false) {
 export const FUNCTION_PARAMETER_MISSMATCH = {};
 
 
-export class FunctionWrapper {
+export class FeelFunction {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   fn: (...args) => any;

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,6 +157,12 @@ export class FeelRange {
 
   constructor(props: FeelRangeProps) {
     Object.assign(this, props);
+
+    // `map` / `includes` are behavior, not identity; keep them
+    // non-enumerable so structural equality and serialization rely on
+    // the range bounds (start / end and their inclusion)
+    Object.defineProperty(this, 'map', { enumerable: false });
+    Object.defineProperty(this, 'includes', { enumerable: false });
   }
 }
 
@@ -278,6 +284,11 @@ export class FeelFunction {
 
     this.fn = fn;
     this.parameterNames = parameterNames;
+
+    // the wrapped implementation is an internal detail; keep it
+    // non-enumerable so serialization and structural comparison rely on
+    // the public parameter names rather than the opaque closure
+    Object.defineProperty(this, 'fn', { enumerable: false });
   }
 
   invoke(contextOrArgs) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ import {
   timeFrom
 } from './temporal.js';
 
-import { FeelRange } from './range.js';
+import { FeelRange, isRange } from './range.js';
 
 export {
   isDate,
@@ -83,11 +83,11 @@ export function getType(e) {
     return 'date time';
   }
 
-  if (e instanceof FeelRange) {
+  if (isRange(e)) {
     return 'range';
   }
 
-  if (e instanceof FeelFunction) {
+  if (isFunction(e)) {
     return 'function';
   }
 
@@ -308,4 +308,11 @@ export class FeelFunction {
 
     return this.fn.call(null, ...params);
   }
+}
+
+/**
+ * Whether the value is a FEEL <function>.
+ */
+export function isFunction(obj) : obj is FeelFunction {
+  return obj instanceof FeelFunction;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,13 +13,16 @@ import {
   timeFrom
 } from './temporal.js';
 
+import { FeelRange } from './range.js';
+
 export {
   isDate,
   isTime,
   isDateTime,
   isDuration,
   isTemporal,
-  isZoned
+  isZoned,
+  FeelRange
 };
 
 export function isNil(e) {
@@ -129,43 +132,6 @@ export function typeCast(obj: any, type: string) {
   return null;
 }
 
-export type FeelRangeProps = {
-  'start included': boolean;
-  'end included': boolean;
-  start: string|number|null;
-  end: string|number|null;
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  map: <T> (fn: (val: any) => T) => T[];
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  includes: (val: any) => boolean;
-};
-
-export class FeelRange {
-
-  'start included': boolean;
-  'end included': boolean;
-  start: string|number|null;
-  end: string|number|null;
-
-
-  map: <T> (fn: (val) => T) => T[];
-
-
-  includes: (val) => boolean;
-
-  constructor(props: FeelRangeProps) {
-    Object.assign(this, props);
-
-    // `map` / `includes` are behavior, not identity; keep them
-    // non-enumerable so structural equality and serialization rely on
-    // the range bounds (start / end and their inclusion)
-    Object.defineProperty(this, 'map', { enumerable: false });
-    Object.defineProperty(this, 'includes', { enumerable: false });
-  }
-}
-
 export function isNumber(obj) : obj is number {
   return typeof obj === 'number';
 }
@@ -255,12 +221,12 @@ export function equals(a, b, strict = false) {
   }
 
   if (aType === 'range') {
-    return [
-      [ a.start, b.start ],
-      [ a.end, b.end ],
-      [ a['start included'], b['start included'] ],
-      [ a['end included'], b['end included'] ]
-    ].every(([ a, b ]) => a === b);
+    return (
+      a['start included'] === b['start included'] &&
+      a['end included'] === b['end included'] &&
+      equals(a.start, b.start) === true &&
+      equals(a.end, b.end) === true
+    );
   }
 
   if (a == b) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,8 @@ import {
 
 import { FeelRange, isRange } from './range.js';
 
+import { isFunction } from './function.js';
+
 export {
   isDate,
   isTime,
@@ -236,83 +238,3 @@ export function equals(a, b, strict = false) {
   return aType === bType ? false : null;
 }
 
-export const FUNCTION_PARAMETER_MISSMATCH = {};
-
-
-export class FeelFunction {
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fn: (...args) => any;
-  parameterNames: string[];
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  constructor(fn: (...args) => any, parameterNames: string[]) {
-
-    this.fn = fn;
-    this.parameterNames = parameterNames;
-
-    // the wrapped implementation is an internal detail; keep it
-    // non-enumerable so serialization and structural comparison rely on
-    // the public parameter names rather than the opaque closure
-    Object.defineProperty(this, 'fn', { enumerable: false });
-  }
-
-  invoke(contextOrArgs) {
-
-    let params;
-
-    if (isArray(contextOrArgs)) {
-      params = contextOrArgs;
-
-      // reject
-      if (params.length > this.parameterNames.length) {
-
-        const lastParam = this.parameterNames[this.parameterNames.length - 1];
-
-        // strictly check for parameter count provided
-        // for non var-args functions
-        if (!lastParam || !lastParam.startsWith('...')) {
-          return FUNCTION_PARAMETER_MISSMATCH;
-        }
-      }
-    } else {
-
-      // strictly check for required parameter names,
-      // and fail on wrong parameter name
-      if (Object.keys(contextOrArgs).some(
-        key => !this.parameterNames.includes(key) && !this.parameterNames.includes(`...${key}`)
-      )) {
-        return FUNCTION_PARAMETER_MISSMATCH;
-      }
-
-      params = this.parameterNames.reduce((params, name) => {
-
-        if (name.startsWith('...')) {
-          name = name.slice(3);
-
-          const value = contextOrArgs[name];
-
-          if (!value) {
-            return params;
-          } else {
-
-            // ensure that single arg provided for var args named
-            // parameter is wrapped in a list
-            return [ ...params, ...(isArray(value) ? value : [ value ]) ];
-          }
-        }
-
-        return [ ...params, contextOrArgs[name] ];
-      }, []);
-    }
-
-    return this.fn.call(null, ...params);
-  }
-}
-
-/**
- * Whether the value is a FEEL <function>.
- */
-export function isFunction(obj) : obj is FeelFunction {
-  return obj instanceof FeelFunction;
-}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,29 +3,6 @@ import { normalizeContextKey } from 'lezer-feel';
 import { getType } from './types.js';
 
 
-export function parseParameterNames(fn) {
-
-  if (Array.isArray(fn.$args)) {
-    return fn.$args;
-  }
-
-  const code = fn.toString();
-
-  const match = /^(?:[^(]*\s*)?\(([^)]+)?\)/.exec(code);
-
-  if (!match) {
-    throw new Error('failed to parse params: ' + code);
-  }
-
-  const [ _, params ] = match;
-
-  if (!params) {
-    return [];
-  }
-
-  return params.split(',').map(p => p.trim());
-}
-
 export function notImplemented(thing) {
   return new Error(`not implemented: ${thing}`);
 }

--- a/test/builtins-spec.js
+++ b/test/builtins-spec.js
@@ -821,6 +821,19 @@ function describeBuiltins(name, evaluate) {
       expr('includes( [1..10], 11 )', false);
       expr('includes( [1..a], 11 )', true, { a: 11 });
       expr('includes( [1..a], 11 )', false, { a: 10 });
+
+      // temporal ranges (compared via a category-aware comparator)
+      expr('before( [date("2020-01-01")..date("2020-06-01")], [date("2020-07-01")..date("2020-12-01")] )', true);
+      expr('before( [date("2020-01-01")..date("2020-08-01")], [date("2020-07-01")..date("2020-12-01")] )', false);
+      expr('after( [date("2020-07-01")..date("2020-12-01")], [date("2020-01-01")..date("2020-06-01")] )', true);
+      expr('meets( [date("2020-01-01")..date("2020-06-01")], [date("2020-06-01")..date("2020-12-01")] )', true);
+      expr('meets( [date("2020-01-01")..date("2020-06-01")), [date("2020-06-01")..date("2020-12-01")] )', false);
+      expr('includes( [date("2020-01-01")..date("2020-12-01")], date("2020-06-15") )', true);
+      expr('includes( [date("2020-01-01")..date("2020-12-01")], date("2021-06-15") )', false);
+      expr('includes( [date("2020-01-01")..date("2020-12-01")], [date("2020-03-01")..date("2020-09-01")] )', true);
+      expr('before( [duration("P1D")..duration("P5D")], [duration("P7D")..duration("P9D")] )', true);
+      expr('includes( [duration("P1D")..duration("P10D")], duration("P5D") )', true);
+      expr('includes( [duration("P1D")..duration("P10D")], duration("P20D") )', false);
     });
 
 

--- a/test/interpreter-spec.js
+++ b/test/interpreter-spec.js
@@ -6,11 +6,29 @@ import {
   unaryTest,
   evaluate,
   date,
-  duration
+  duration,
+  FeelRange,
+  FeelFunction
 } from 'feelin';
 
 
 describe('interpreter', function() {
+
+  describe('public API', function() {
+
+    it('should expose wrapper classes', function() {
+      expect(FeelRange).to.be.a('function');
+      expect(FeelFunction).to.be.a('function');
+    });
+
+
+    it('should return wrapper values from evaluate', function() {
+      expect(evaluate('[1..10]').value).to.be.an.instanceof(FeelRange);
+      expect(evaluate('function(x) x + 1').value).to.be.an.instanceof(FeelFunction);
+    });
+
+  });
+
 
   describe('evaluate', function() {
 

--- a/test/interpreter-spec.js
+++ b/test/interpreter-spec.js
@@ -8,7 +8,9 @@ import {
   date,
   duration,
   FeelRange,
-  FeelFunction
+  FeelFunction,
+  isRange,
+  isFunction
 } from 'feelin';
 
 
@@ -25,6 +27,26 @@ describe('interpreter', function() {
     it('should return wrapper values from evaluate', function() {
       expect(evaluate('[1..10]').value).to.be.an.instanceof(FeelRange);
       expect(evaluate('function(x) x + 1').value).to.be.an.instanceof(FeelFunction);
+    });
+
+
+    it('should expose <isRange> guard', function() {
+      expect(isRange).to.be.a('function');
+
+      expect(isRange(evaluate('[1..10]').value)).to.be.true;
+      expect(isRange(evaluate('function(x) x + 1').value)).to.be.false;
+      expect(isRange(5)).to.be.false;
+      expect(isRange(null)).to.be.false;
+    });
+
+
+    it('should expose <isFunction> guard', function() {
+      expect(isFunction).to.be.a('function');
+
+      expect(isFunction(evaluate('function(x) x + 1').value)).to.be.true;
+      expect(isFunction(evaluate('[1..10]').value)).to.be.false;
+      expect(isFunction(5)).to.be.false;
+      expect(isFunction(null)).to.be.false;
     });
 
   });


### PR DESCRIPTION
### Which issue does this PR address?

This ensures we consistently export helper types with the name `Feel*`, alongside with guards `isRange`, `isFunction` to check for their types.

Valuable in edge cases, when your expression returns actual intermittent FEEL types, not plain values.

Also: Restructure internals to clearly separate into `temporal`, `range` and `function` domains.