### PR TITLE
Preserve var-args falsy values

### DIFF
--- a/src/function.ts
+++ b/src/function.ts
@@ -18,7 +18,7 @@ import { isRange } from './range.js';
  * Sentinel returned by {@link FeelFunction#invoke} when the provided
  * arguments do not match the function's parameters.
  */
-export const FUNCTION_PARAMETER_MISSMATCH = {};
+export const FUNCTION_PARAMETER_MISMATCH = {};
 
 
 export class FeelFunction {
@@ -54,7 +54,7 @@ export class FeelFunction {
         // strictly check for parameter count provided
         // for non var-args functions
         if (!lastParam || !lastParam.startsWith('...')) {
-          return FUNCTION_PARAMETER_MISSMATCH;
+          return FUNCTION_PARAMETER_MISMATCH;
         }
       }
     } else {
@@ -64,7 +64,7 @@ export class FeelFunction {
       if (Object.keys(contextOrArgs).some(
         key => !this.parameterNames.includes(key) && !this.parameterNames.includes(`...${key}`)
       )) {
-        return FUNCTION_PARAMETER_MISSMATCH;
+        return FUNCTION_PARAMETER_MISMATCH;
       }
 
       params = this.parameterNames.reduce((params, name) => {

--- a/src/function.ts
+++ b/src/function.ts
@@ -1,4 +1,4 @@
-import { isArray } from './types.js';
+import { isArray, isNil } from './types.js';
 
 import { isRange } from './range.js';
 
@@ -74,7 +74,7 @@ export class FeelFunction {
 
           const value = contextOrArgs[name];
 
-          if (!value) {
+          if (isNil(value)) {
             return params;
           } else {
 

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -20,7 +20,7 @@ import {
 } from './range.js';
 
 import {
-  FUNCTION_PARAMETER_MISSMATCH,
+  FUNCTION_PARAMETER_MISMATCH,
   wrapFunction
 } from './function.js';
 
@@ -781,7 +781,7 @@ function evalNode(node: Node, args: any[], interpreterContext: InterpreterContex
 
       const result = wrappedFn.invoke(contextOrArgs);
 
-      if (result === FUNCTION_PARAMETER_MISSMATCH) {
+      if (result === FUNCTION_PARAMETER_MISMATCH) {
         interpreterContext.addWarning(node, 'FUNCTION_INVOCATION_FAILURE', {
           template: 'Cannot invoke {target} with parameters {params}',
           values: {
@@ -835,7 +835,7 @@ function evalNode(node: Node, args: any[], interpreterContext: InterpreterContex
 
     const result = wrappedFn.invoke(contextOrArgs);
 
-    if (result === FUNCTION_PARAMETER_MISSMATCH) {
+    if (result === FUNCTION_PARAMETER_MISMATCH) {
       interpreterContext.addWarning(node, 'FUNCTION_INVOCATION_FAILURE', {
         template: 'Cannot invoke {target} with parameters {params}',
         values: {

--- a/test/interpreter-spec.js
+++ b/test/interpreter-spec.js
@@ -301,6 +301,24 @@ describe('interpreter', function() {
         }
       });
 
+      expr('foo(varArgs: 0)', [ [ 0 ] ], {
+        foo: function(...varArgs) {
+          return [ varArgs ];
+        }
+      });
+
+      expr('foo(varArgs: false)', [ [ false ] ], {
+        foo: function(...varArgs) {
+          return [ varArgs ];
+        }
+      });
+
+      expr('foo(varArgs: "")', [ [ '' ] ], {
+        foo: function(...varArgs) {
+          return [ varArgs ];
+        }
+      });
+
     });
 
 


### PR DESCRIPTION
### Which issue does this PR address?

A named var-args parameter whose value was falsy (0, false, "") was
dropped, since the guard used a truthiness check instead of a nil
check. Only skip the parameter when it is actually nil.