### PR TITLE
Reject mixed-kind duration arithmetic, keep days as days

### DIFF
--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -326,19 +326,23 @@ function evalNode(node: Node, args: any[], interpreterContext: InterpreterContex
   switch (node.name) {
   case 'ArithOp': return (context) => {
 
+    const invalidType = (opName, left, right) => {
+      interpreterContext.addWarning(node, 'INVALID_TYPE', {
+        template: `Can't ${opName} {right} to {left}`,
+        values: {
+          left,
+          right
+        }
+      });
+    };
+
     const nullable = (op, opName, types = [ 'number' ]) => (a, b) => {
 
       const left = a(context);
       const right = b(context);
 
       if (isArray(left) || isArray(right)) {
-        interpreterContext.addWarning(node, 'INVALID_TYPE', {
-          template: `Can't ${opName} {right} to {left}`,
-          values: {
-            left,
-            right
-          }
-        });
+        invalidType(opName, left, right);
 
         return null;
       }
@@ -350,24 +354,12 @@ function evalNode(node: Node, args: any[], interpreterContext: InterpreterContex
 
       if (temporal.includes(leftType)) {
         if (!temporal.includes(rightType)) {
-          interpreterContext.addWarning(node, 'INVALID_TYPE', {
-            template: `Can't ${opName} {right} to {left}`,
-            values: {
-              left,
-              right
-            }
-          });
+          invalidType(opName, left, right);
 
           return null;
         }
       } else if (leftType !== rightType || !types.includes(leftType)) {
-        interpreterContext.addWarning(node, 'INVALID_TYPE', {
-          template: `Can't ${opName} {right} to {left}`,
-          values: {
-            left,
-            right
-          }
-        });
+        invalidType(opName, left, right);
 
         return null;
       }
@@ -390,7 +382,13 @@ function evalNode(node: Node, args: any[], interpreterContext: InterpreterContex
       } else if (isTemporal(a) && isTemporal(b)) {
         return null;
       } else if (isDuration(a) && isDuration(b)) {
-        return addDurations(a, b, 1);
+        const result = addDurations(a, b, 1);
+
+        if (result === null) {
+          invalidType('add', a, b);
+        }
+
+        return result;
       }
 
       return a + b;
@@ -401,7 +399,13 @@ function evalNode(node: Node, args: any[], interpreterContext: InterpreterContex
       } else if (isTemporal(a) && isTemporal(b)) {
         return subtractTemporals(a, b);
       } else if (isDuration(a) && isDuration(b)) {
-        return addDurations(a, b, -1);
+        const result = addDurations(a, b, -1);
+
+        if (result === null) {
+          invalidType('subtract', a, b);
+        }
+
+        return result;
       }
 
       return a - b;

--- a/src/temporal.ts
+++ b/src/temporal.ts
@@ -610,25 +610,35 @@ export function subtractTemporals(a: FeelTemporal, b: FeelTemporal) : FeelDurati
 }
 
 /**
- * Add or subtract two durations.
+ * Add (`sign > 0`) or subtract (`sign < 0`) two durations of the same
+ * kind, returning `null` for a mixed-kind combination.
+ *
+ * Years / months and days / time durations are distinct FEEL types;
+ * combining the two kinds is undefined (mirroring camunda/feel-scala,
+ * which has no mixed-kind arithmetic case and yields `null`).
  */
-export function addDurations(a: FeelDuration, b: FeelDuration, sign: number) : FeelDuration {
+export function addDurations(a: FeelDuration, b: FeelDuration, sign: number) : FeelDuration | null {
+
+  if (a.yearsMonths !== b.yearsMonths) {
+    return null;
+  }
 
   const other = sign < 0 ? b.value.negated() : b.value;
 
-  // anchor to a reference point so mixed years / months and days / time
-  // durations can be combined without a calendar-less RangeError
-  const anchor = REFERENCE_DATE.toPlainDateTime();
+  if (a.yearsMonths) {
 
-  const result = anchor.add(a.value).add(other).since(anchor, { largestUnit: 'year' });
+    // years / months balance calendar-independently (12 months = 1 year),
+    // but Temporal requires an anchor to add year / month durations
+    const anchor = REFERENCE_DATE.toPlainDateTime();
 
-  // keep the category from the value; only fall back to the operands'
-  // category when the result is zero (and thus category-less)
-  const yearsMonths = result.sign === 0
-    ? a.yearsMonths || b.yearsMonths
-    : isYearsMonths(result);
+    const result = anchor.add(a.value).add(other).since(anchor, { largestUnit: 'year' });
 
-  return new FeelDuration(result, yearsMonths);
+    return new FeelDuration(result, true);
+  }
+
+  // days / time add directly; days stay 24h units (no calendar balancing,
+  // so P20D + P20D is P40D rather than P1M9D)
+  return new FeelDuration(a.value.add(other), false);
 }
 
 /**

--- a/test/interpreter-spec.js
+++ b/test/interpreter-spec.js
@@ -166,6 +166,25 @@ describe('interpreter', function() {
         expr('duration("P1D") + duration("P1D")', duration('P2D'));
         expr('duration("PT1M") + duration("PT1M")', duration('PT2M'));
 
+        // days / time durations add as 24h day units, without balancing
+        // into calendar months (P20D + P20D = P40D, not P1M9D)
+        expr('duration("P20D") + duration("P20D")', duration('P40D'));
+        expr('duration("P25D") + duration("P10D")', duration('P35D'));
+
+        // years / months durations add independently of any calendar
+        expr('duration("P1Y") + duration("P2M") = duration("P1Y2M")', true);
+        expr('duration("P1Y2M") - duration("P6M") = duration("P8M")', true);
+        expr('duration("P18M") + duration("P0M") = duration("P1Y6M")', true);
+        expr('string(duration("P1Y") + duration("P2M"))', 'P1Y2M');
+
+        // years / months and days / time durations are distinct FEEL types;
+        // combining the two kinds is undefined and yields null (mirrors
+        // camunda/feel-scala, which has no mixed-kind arithmetic case)
+        expr('duration("P1Y") + duration("P1D")', null);
+        expr('duration("P1D") + duration("P1Y")', null);
+        expr('duration("P1Y") - duration("P1D")', null);
+        expr('duration("P0Y") + duration("P0D")', null);
+
         expr('date("2023-10-06") + duration("PT1H")', date('2023-10-06T01:00Z'));
         expr('date("2023-10-06") + duration("P1D")', date('2023-10-07'));
         expr('date("2023-10-06") + duration("P1W")', date('2023-10-13'));
@@ -1723,6 +1742,34 @@ describe('interpreter', function() {
               values: {
                 right: 10,
                 left: date('2025-12-12')
+              }
+            }
+          }
+        ]);
+      });
+
+
+      it('INVALID_TYPE for mixed-kind duration arithmetic', function() {
+
+        // when
+        const {
+          value,
+          warnings
+        } = evaluate('duration("P1Y") + duration("P1D")');
+
+        // then
+        expect(value).to.be.null;
+
+        expect(warnings).to.eql([
+          {
+            type: 'INVALID_TYPE',
+            message: "Can't add 'P1D' to 'P1Y'",
+            position: { from: 16, to: 17 },
+            details: {
+              template: "Can't add {right} to {left}",
+              values: {
+                left: duration('P1Y'),
+                right: duration('P1D')
               }
             }
           }


### PR DESCRIPTION
### Which issue does this PR address?

Adding or subtracting durations of different kinds (a years / months and a days / time duration) is undefined in FEEL and now yields null, rather than fabricating a mixed P1Y1D value. This mirrors camunda/feel-scala, which has no mixed-kind arithmetic case.

Same-kind days / time durations also no longer balance into calendar months (P20D + P20D is P40D, not P1M9D), which the previous year-anchored combine produced.

Closes https://github.com/nikku/feelin/issues/106