### PR TITLE
fix(builtins): return null for date(year, month, day, from)

### DIFF
--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -207,7 +207,12 @@ const builtins = {
       d = dateOf(from);
     }
 
-    if (year) {
+    if (isNumber(year)) {
+
+      // the (year, month, day) form does not accept a <from> argument
+      if (from != null) {
+        return null;
+      }
 
       if (!isNumber(month) || !isNumber(day)) {
         return null;

--- a/test/builtins-spec.js
+++ b/test/builtins-spec.js
@@ -640,7 +640,7 @@ function describeBuiltins(name, evaluate) {
       expr('date(2017,-8,2)', null);
       expr('date(2017,12,32)', null);
       expr('date(2017,13,31)', null);
-      exprSkip('date(2016, 1, 15, 100)', null);
+      expr('date(2016, 1, 15, 100)', null);
 
       expr('date("")', null);
       expr('date(2017,null,1)', null);


### PR DESCRIPTION
### Which issue does this PR address?

The `(year, month, day)` and `(from)` forms of `date()` are mutually exclusive; reject calls that combine them.
