### PR TITLE
fix(temporal): reject week durations (unsupported in FEEL)

### DIFF
--- a/src/temporal.ts
+++ b/src/temporal.ts
@@ -523,10 +523,17 @@ export function durationEquals(a: FeelDuration, b: FeelDuration) : boolean {
   return Math.trunc(total(a, 'second') - total(b, 'second')) === 0;
 }
 
-export function duration(opts: string | number) : FeelDuration {
+export function duration(opts: string | number) : FeelDuration | null {
 
   if (typeof opts === 'number') {
     return new FeelDuration(Temporal.Duration.from({ milliseconds: opts }), false);
+  }
+
+  // FEEL durations are years-and-months or days-and-time durations only;
+  // the ISO-8601 week designator (`W`) is not part of the FEEL grammar,
+  // even though the underlying temporal implementation would accept it
+  if (/\d+W/i.test(opts)) {
+    return null;
   }
 
   return new FeelDuration(Temporal.Duration.from(opts), isYearsMonthsString(opts));

--- a/test/builtins-spec.js
+++ b/test/builtins-spec.js
@@ -684,6 +684,13 @@ function describeBuiltins(name, evaluate) {
       expr('duration("P7D") + date and time("2020-04-06T08:00:00") = date and time("2020-04-13T08:00:00")', true);
       expr('duration("P2D") + duration("P5D") = duration("P7D")', true);
 
+      // weeks are not part of the FEEL duration grammar, even though
+      // ISO-8601 allows them (see #105)
+      expr('duration("P1W")', null);
+      expr('duration("P2W")', null);
+      expr('duration("-P1W")', null);
+      expr('@"P1W"', null);
+
 
       describe('properties', function() {
 

--- a/test/interpreter-spec.js
+++ b/test/interpreter-spec.js
@@ -187,12 +187,12 @@ describe('interpreter', function() {
 
         expr('date("2023-10-06") + duration("PT1H")', date('2023-10-06T01:00Z'));
         expr('date("2023-10-06") + duration("P1D")', date('2023-10-07'));
-        expr('date("2023-10-06") + duration("P1W")', date('2023-10-13'));
+        expr('date("2023-10-06") + duration("P7D")', date('2023-10-13'));
         expr('date("2023-10-06") + duration("P1M")', date('2023-11-06'));
         expr('date("2023-10-06") + duration("P1Y")', date('2024-10-06'));
         expr('date("2023-10-06") - duration("PT1H")', date('2023-10-05T23:00Z'));
         expr('date("2023-10-06") - duration("P1D")', date('2023-10-05'));
-        expr('date("2023-10-06") - duration("P1W")', date('2023-09-29'));
+        expr('date("2023-10-06") - duration("P7D")', date('2023-09-29'));
         expr('date("2023-10-06") - duration("P1M")', date('2023-09-06'));
         expr('date("2023-10-06") - duration("P1Y")', date('2022-10-06'));
         expr('date("2023-10-06") + duration("P1M") = date("2023-11-06")', true);


### PR DESCRIPTION
## What

`duration("P1W")` currently yields a 7-day duration (`P7D`) instead of `null`.

The FEEL duration grammar only supports **years, months, days and time** components. ISO-8601 week durations (the `W` designator) are **not** part of it, even though the underlying temporal implementation (`temporal-polyfill`) happily accepts and normalizes them to days. This makes expressions that should evaluate to `null` per the FEEL spec succeed in feelin.

## Change

`duration()` now returns `null` when the ISO string carries a week component. This propagates through both the `duration(...)` builtin and the `@"..."` literal.

```
duration("P1W")   // was P7D, now null
@"P1W"            // was P7D, now null
duration("P1Y2M") // unchanged
duration("P1DT2H")// unchanged
```

## Tests

- Added assertions in `test/builtins-spec.js` covering `duration("P1W")`, `duration("P2W")`, `duration("-P1W")` and `@"P1W"` → `null`.
- Two existing arithmetic tests that used `duration("P1W")` (encoding the buggy behavior) were switched to the equivalent `duration("P7D")`, keeping week-length arithmetic coverage.

Closes #105