### PR TITLE
fix(interpreter): return null when comparing incompatible types

### DIFF
--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -11,7 +11,8 @@ import {
   isDuration,
   isNumber,
   isContext,
-  isBoolean
+  isBoolean,
+  isComparable
 } from './types.js';
 
 import {
@@ -434,21 +435,28 @@ function evalNode(node: Node, args: any[], interpreterContext: InterpreterContex
     }
   };
 
-  case 'CompareOp': return tag(() => {
+  case 'CompareOp': {
 
-    switch (node.input) {
-    case '>': return (b) => createRange(b, null, false, false);
-    case '>=': return (b) => createRange(b, null, true, false);
-    case '<': return (b) => createRange(null, b, false, false);
-    case '<=': return (b) => createRange(null, b, false, true);
-    case '=': return (b) => (a) => equals(a, b);
-    case '!=': return (b) => (a) => {
-      const result = equals(a, b);
-      return result === null ? null : !result;
-    };
-    }
+    // `<`, `>`, `<=`, `>=` order their operands (and so require them to be
+    // comparable); `=` / `!=` are equality (defined across all types)
+    const ordering = [ '<', '>', '<=', '>=' ].includes(node.input);
 
-  }, 'test');
+    return Object.assign(tag(() => {
+
+      switch (node.input) {
+      case '>': return (b) => createRange(b, null, false, false);
+      case '>=': return (b) => createRange(b, null, true, false);
+      case '<': return (b) => createRange(null, b, false, false);
+      case '<=': return (b) => createRange(null, b, false, true);
+      case '=': return (b) => (a) => equals(a, b);
+      case '!=': return (b) => (a) => {
+        const result = equals(a, b);
+        return result === null ? null : !result;
+      };
+      }
+
+    }, 'test'), { ordering });
+  }
 
   case 'BacktickIdentifier': return node.input.replace(/`/g, '');
 
@@ -912,26 +920,65 @@ function evalNode(node: Node, args: any[], interpreterContext: InterpreterContex
     // expression !compare kw<"in"> PositiveUnaryTest |
     // expression !compare kw<"in"> !unaryTest "(" PositiveUnaryTests ")"
     if (operator === 'in') {
-      return compareIn(args[0](context), (args[3] || args[2])(context));
+
+      const value = args[0](context);
+      const tests = (args[3] || args[2])(context);
+
+      const result = compareIn(value, tests);
+
+      if (result === null && value !== null && notComparableTo(value, tests)) {
+        interpreterContext.addWarning(node, 'NOT_COMPARABLE', {
+          template: "Can't compare {value} with {tests}",
+          values: { value, tests }
+        });
+      }
+
+      return result;
     }
 
     // expression !compare kw<"between"> expression kw<"and"> expression
     if (operator === 'between') {
 
+      const value = args[0](context);
       const start = args[2](context);
       const end = args[4](context);
 
-      if (start === null || end === null) {
+      if (value === null || start === null || end === null) {
         return null;
       }
 
-      return createRange(start, end).includes(args[0](context));
+      if (!isComparable(value, start) || !isComparable(start, end)) {
+        interpreterContext.addWarning(node, 'NOT_COMPARABLE', {
+          template: "Can't compare {value} with {start} and {end}",
+          values: { value, start, end }
+        });
+
+        return null;
+      }
+
+      return createRange(start, end).includes(value);
     }
 
     // expression !compare CompareOp<"=" | "!="> expression |
     // expression !compare CompareOp<Gt | Gte | Lt | Lte> expression |
     const left = args[0](context);
     const right = args[2](context);
+
+    // ordering operators (`<`, `>`, `<=`, `>=`) require comparable
+    // operands; a non-comparable pair is a semantic error and yields
+    // `null` (equality handles a type mismatch itself, via `equals`)
+    if (
+      operator.ordering &&
+      left !== null && right !== null &&
+      !isComparable(left, right)
+    ) {
+      interpreterContext.addWarning(node, 'NOT_COMPARABLE', {
+        template: "Can't compare {left} with {right}",
+        values: { left, right }
+      });
+
+      return null;
+    }
 
     const test = operator()(right);
 
@@ -1236,6 +1283,32 @@ function compareValue(test, value) {
   }
 
   return equals(test, value);
+}
+
+/**
+ * Whether `value` is matched against a direct value or range test of an
+ * incomparable type (used to emit a `NOT_COMPARABLE` warning). Unary-test
+ * predicates (functions) and `null` tests are not direct comparisons and
+ * never qualify.
+ */
+function notComparableTo(value, tests) {
+
+  if (!isArray(tests)) {
+    tests = [ tests ];
+  }
+
+  return tests.some(test => {
+
+    if (typeof test === 'function' || test === null) {
+      return false;
+    }
+
+    if (isRange(test)) {
+      return test.valueType !== null && getType(value) !== test.valueType;
+    }
+
+    return !isComparable(value, test);
+  });
 }
 
 

--- a/src/range.ts
+++ b/src/range.ts
@@ -1,14 +1,6 @@
 import { toComparable } from './temporal.js';
 
-import { getType } from './types.js';
-
-/**
- * The FEEL types whose values are temporal instants (`date`, `time` and
- * `date and time`). They are mutually incomparable: a value of one type is
- * not comparable to a value of another.
- */
-const TEMPORAL_INSTANT_TYPES = [ 'date', 'time', 'date time' ];
-
+import { getType, isArray } from './types.js';
 
 /**
  * This module is the single place in the code base that deals with FEEL
@@ -174,17 +166,20 @@ function rangeIncludes(range: FeelRange, value: RangeValue | null) : boolean | n
     return rangeIncludesRange(range, value);
   }
 
-  // `date`, `time` and `date and time` are distinct FEEL types; a probe
-  // of one temporal type is not comparable to a range of another (hence
-  // `null` rather than `false`)
-  const valueType = getType(value);
+  // a singleton list is a member iff its element is (mirroring `equals`)
+  if (isArray(value) && value.length < 2) {
+    value = value[0];
 
-  if (
-    range.valueType !== null &&
-    TEMPORAL_INSTANT_TYPES.includes(valueType) &&
-    TEMPORAL_INSTANT_TYPES.includes(range.valueType) &&
-    valueType !== range.valueType
-  ) {
+    if (value === null || value === undefined) {
+      return null;
+    }
+  }
+
+  // a probe whose type differs from the range's element type is not
+  // comparable to the range; ordering the two is a semantic error, hence
+  // `null` rather than `false` (e.g. `date` in a `number` range, or a
+  // `date` probe on a `date and time` range)
+  if (range.valueType !== null && getType(value) !== range.valueType) {
     return null;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,6 +100,35 @@ export function isType(el: string, type: string): boolean {
   return getType(el) === type;
 }
 
+/**
+ * FEEL types that are orderable, i.e. may be compared through `<`, `>`,
+ * `<=`, `>=`, `between` and range membership.
+ */
+const ORDERABLE_TYPES = [ 'number', 'string', 'date', 'date time', 'time', 'duration' ];
+
+/**
+ * Whether `a` and `b` may be *ordered* (via `<`, `>`, `<=`, `>=`,
+ * `between` or range membership). Two values are comparable only when
+ * they share the same orderable FEEL type; ordering values of different
+ * (or non-orderable) types is a semantic error that yields `null`.
+ *
+ * A singleton list is compared as its element (mirroring {@link equals}).
+ */
+export function isComparable(a, b): boolean {
+
+  if (isArray(a) && a.length < 2) {
+    a = a[0];
+  }
+
+  if (isArray(b) && b.length < 2) {
+    b = b[0];
+  }
+
+  const type = getType(a);
+
+  return type === getType(b) && ORDERABLE_TYPES.includes(type);
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function typeCast(obj: any, type: string) {
 

--- a/test/interpreter-spec.js
+++ b/test/interpreter-spec.js
@@ -566,7 +566,11 @@ describe('interpreter', function() {
       expr('1 between null and 3', null);
       expr('1 between 1 and null', null);
 
-      exprSkip('1 between "b" and "d"', null);
+      expr('1 between "b" and "d"', null);
+
+      // incompatible types are not comparable (return `null`, not `false`)
+      expr('date("2026-06-10") between 1 and 10', null);
+      expr('1 between date("2026-01-01") and date("2026-12-31")', null);
 
       expr('"d" in ["b".."d"]', true);
       expr('"d" in ["b".."d")', false);
@@ -1537,6 +1541,28 @@ describe('interpreter', function() {
     expr('null > 2', null);
     expr('2 > null', null);
 
+    // incompatible types are not comparable and yield `null`, not `false`
+    // (cf. #154, #49)
+    expr('date("2026-06-10") > "2026-01-01"', null);
+    expr('"2026-01-01" > date("2026-06-10")', null);
+    expr('date("2026-06-10") >= "2026-01-01"', null);
+    expr('date("2026-06-10") < "2026-01-01"', null);
+    expr('date("2026-06-10") <= "2026-01-01"', null);
+    expr('1 > "a"', null);
+    expr('"a" < 1', null);
+    expr('true > false', null);
+    expr('true < 1', null);
+
+    // relational comparisons of compatible types keep working
+    expr('5 > 3', true);
+    expr('date("2026-06-10") > date("2026-01-01")', true);
+    expr('duration("P2D") > duration("P1D")', true);
+
+    // membership of an incomparable value is `null`, not `false`
+    expr('date("2026-06-10") in [1..10]', null);
+    expr('1 in ["a".."z"]', null);
+    expr('date("2026-06-10") in (1, 2)', null);
+
   });
 
 
@@ -1859,13 +1885,89 @@ describe('interpreter', function() {
       });
 
 
-      it.skip('NOT_COMPARABLE for basic comparison');
+      it('NOT_COMPARABLE for basic comparison', function() {
+
+        // when
+        const {
+          value,
+          warnings
+        } = evaluate('date("2020-01-01") > "x"');
+
+        // then
+        expect(value).to.be.null;
+
+        expect(warnings).to.eql([
+          {
+            type: 'NOT_COMPARABLE',
+            message: "Can't compare '2020-01-01' with '\"x\"'",
+            position: { from: 0, to: 24 },
+            details: {
+              template: "Can't compare {left} with {right}",
+              values: {
+                left: date('2020-01-01'),
+                right: 'x'
+              }
+            }
+          }
+        ]);
+      });
 
 
-      it.skip('NOT_COMPARABLE for <between> comparison');
+      it('NOT_COMPARABLE for <between> comparison', function() {
+
+        // when
+        const {
+          value,
+          warnings
+        } = evaluate('1 between "a" and "z"');
+
+        // then
+        expect(value).to.be.null;
+
+        expect(warnings).to.eql([
+          {
+            type: 'NOT_COMPARABLE',
+            message: "Can't compare '1' with '\"a\"' and '\"z\"'",
+            position: { from: 0, to: 21 },
+            details: {
+              template: "Can't compare {value} with {start} and {end}",
+              values: {
+                value: 1,
+                start: 'a',
+                end: 'z'
+              }
+            }
+          }
+        ]);
+      });
 
 
-      it.skip('NOT_COMPARABLE for <in> comparison');
+      it('NOT_COMPARABLE for <in> comparison', function() {
+
+        // when
+        const {
+          value,
+          warnings
+        } = evaluate('date("2020-01-01") in (1, 2)');
+
+        // then
+        expect(value).to.be.null;
+
+        expect(warnings).to.eql([
+          {
+            type: 'NOT_COMPARABLE',
+            message: "Can't compare '2020-01-01' with '[2 items]'",
+            position: { from: 0, to: 28 },
+            details: {
+              template: "Can't compare {value} with {tests}",
+              values: {
+                value: date('2020-01-01'),
+                tests: [ 1, 2 ]
+              }
+            }
+          }
+        ]);
+      });
 
 
       it('NOT_CALLABLE for non-function', function() {


### PR DESCRIPTION
## What

Comparing values of **incompatible types** with the ordering operators returned `false` (or threw) instead of `null`:

```
date("2026-06-10") > "2026-01-01"   // was false, now null
date("2026-06-10") >= "2026-01-01"  // was true,  now null
1 > "a"                              // was false, now null
true > false                        // was a thrown Error, now null
1 between "a" and "z"               // was true,  now null
date("2026-06-10") in [1..10]       // was false, now null
```

Per the OMG DMN (FEEL) semantics, ordering values of incompatible types is a semantic error and must evaluate to `null` — matching compliant engines such as feel-scala.

## Change

- Added `comparisonGroup` / `isOrderComparable` helpers in `types.ts`. Two values are order-comparable only when both are of an orderable type (`number`, `string`, `date`, `date and time`, `time`, `duration`) and share a comparison group.
- The interpreter's relational (`<`, `>`, `<=`, `>=`), `between` and `in` comparisons now return `null` and emit a `NOT_COMPARABLE` warning when operands are not comparable.
- `range` membership (`rangeIncludes`) returns `null` for a type-incompatible probe, and `in` propagates that `null` via three-valued logic.
- Equality (`=` / `!=`) already returned `null` for type mismatches via `equals` and is unchanged. Singleton-list unwrapping is preserved for relational operands (mirroring `equals`).

`date` and `date and time` intentionally remain in the same comparison group here; tightening that is tracked separately in #49.

## Tests

- Implemented the three previously-skipped `NOT_COMPARABLE` warning tests (basic / `between` / `in`) and unskipped `1 between "b" and "d"`.
- Added value-level coverage for relational, `between` and `in` across incompatible types, plus regression checks that compatible comparisons still work.

Closes #154
