### PR TITLE
fix: date, time and date and time are not comparable (#49)

### DIFF
--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -442,7 +442,10 @@ function evalNode(node: Node, args: any[], interpreterContext: InterpreterContex
     case '<': return (b) => createRange(null, b, false, false);
     case '<=': return (b) => createRange(null, b, false, true);
     case '=': return (b) => (a) => equals(a, b);
-    case '!=': return (b) => (a) => !equals(a, b);
+    case '!=': return (b) => (a) => {
+      const result = equals(a, b);
+      return result === null ? null : !result;
+    };
     }
 
   }, 'test');
@@ -1203,9 +1206,23 @@ function compareIn(value, tests) {
     tests = [ tests ];
   }
 
-  return tests.some(
-    test => compareValue(test, value)
-  );
+  // three-valued membership: a matching test wins, otherwise any
+  // incomparable (null) test makes the whole result unknown (null)
+  let unknown = false;
+
+  for (const test of tests) {
+    const result = compareValue(test, value);
+
+    if (result === true) {
+      return true;
+    }
+
+    if (result === null) {
+      unknown = true;
+    }
+  }
+
+  return unknown ? null : false;
 }
 
 function compareValue(test, value) {

--- a/src/range.ts
+++ b/src/range.ts
@@ -3,6 +3,14 @@ import { toComparable } from './temporal.js';
 import { getType } from './types.js';
 
 /**
+ * The FEEL types whose values are temporal instants (`date`, `time` and
+ * `date and time`). They are mutually incomparable: a value of one type is
+ * not comparable to a value of another.
+ */
+const TEMPORAL_INSTANT_TYPES = [ 'date', 'time', 'date time' ];
+
+
+/**
  * This module is the single place in the code base that deals with FEEL
  * <range> values.
  *
@@ -164,6 +172,20 @@ function rangeIncludes(range: FeelRange, value: RangeValue | null) : boolean | n
 
   if (value instanceof FeelRange) {
     return rangeIncludesRange(range, value);
+  }
+
+  // `date`, `time` and `date and time` are distinct FEEL types; a probe
+  // of one temporal type is not comparable to a range of another (hence
+  // `null` rather than `false`)
+  const valueType = getType(value);
+
+  if (
+    range.valueType !== null &&
+    TEMPORAL_INSTANT_TYPES.includes(valueType) &&
+    TEMPORAL_INSTANT_TYPES.includes(range.valueType) &&
+    valueType !== range.valueType
+  ) {
+    return null;
   }
 
   // normalize a descending range (e.g. `[10..1]`) so bounds are ordered

--- a/src/types.ts
+++ b/src/types.ts
@@ -169,17 +169,16 @@ export function equals(a, b, strict = false) {
       return null;
     }
 
-    if ((aType === 'time') !== (bType === 'time')) {
-      return null;
-    }
-
-    // strict equality (`is`) does not coerce across temporal types
-    if (strict && aType !== bType) {
-      return false;
+    // `date`, `time` and `date and time` are distinct FEEL types; a value
+    // of one type is never comparable to a value of another. Strict
+    // equality (`is`) yields `false` for such a mismatch, a regular
+    // comparison yields `null`.
+    if (aType !== bType) {
+      return strict ? false : null;
     }
 
     // a zoned and a zone-less temporal of the same type are never equal
-    if (aType === bType && isZoned(a) !== isZoned(b)) {
+    if (isZoned(a) !== isZoned(b)) {
       return false;
     }
 

--- a/test/builtins-spec.js
+++ b/test/builtins-spec.js
@@ -591,7 +591,7 @@ function describeBuiltins(name, evaluate) {
 
       expr('@"2014-12-31T23:59:59" = date and time("2014-12-31T23:59:59")', true);
 
-      expr('is(date("2012-12-25"), time("23:00:50"))', null);
+      expr('is(date("2012-12-25"), time("23:00:50"))', false);
       expr('is(date("2012-12-25"), @"2012-12-25")', true);
       expr('is(date("2011-12-25"), @"2012-12-25")', false);
 
@@ -632,9 +632,11 @@ function describeBuiltins(name, evaluate) {
         date("2016-01-15") = date(2016, 1, 15)
       `, true);
 
+      // `date`, `time` and `date and time` are distinct FEEL types, so a
+      // `date` is not comparable to a `date and time` (see #49)
       expr(`
         date(2016, 1, 15) = date and time("2016-01-15T00:00:00z")
-      `, true);
+      `, null);
 
       expr('date(1)', null);
       expr('date(2017,8,-2)', null);
@@ -652,9 +654,11 @@ function describeBuiltins(name, evaluate) {
       expr('time(12,null,null,null)', null);
       expr('time(12,11,null,null)', null);
 
+      // `today()` is a `date` and `date and time(...)` a `date and time`;
+      // the two types are not comparable (see #49)
       expr(`
         today() = date and time(now(), @"00:00:00")
-      `, true);
+      `, null);
 
       expr('day of year(@"2016-01-15")', 15);
       expr('day of year(@"2016-11-15")', 320);

--- a/test/interpreter-spec.js
+++ b/test/interpreter-spec.js
@@ -636,6 +636,45 @@ describe('interpreter', function() {
     });
 
 
+    // https://github.com/nikku/feelin/issues/49
+    describe('Comparison > incompatible temporal types', function() {
+
+      // `date`, `time` and `date and time` are distinct FEEL types; a value
+      // of one type is never comparable to a value of another, so any such
+      // comparison is `null` (equality/relational) rather than true/false
+
+      // date <-> date and time
+      expr('date("2024-01-01") = date and time("2024-01-01T00:00:00")', null);
+      expr('date("2024-01-01") != date and time("2024-01-01T00:00:00")', null);
+      expr('date("2024-01-01") < date and time("2024-01-02T00:00:00")', null);
+      expr('date("2024-01-01") <= date and time("2024-01-01T00:00:00")', null);
+      expr('date("2024-01-01") > date and time("2024-01-01T00:00:00")', null);
+      expr('date("2024-01-01") >= date and time("2024-01-01T00:00:00")', null);
+      expr('date and time("2024-01-01T10:00:00") > date("2024-01-01")', null);
+
+      // date <-> time
+      expr('time("10:00:00") = date("2024-01-01")', null);
+      expr('time("10:00:00") > date("2024-01-01")', null);
+
+      // date and time <-> time
+      expr('date and time("2024-01-01T10:00:00") = time("10:00:00")', null);
+      expr('date and time("2024-01-01T10:00:00") < time("11:00:00")', null);
+
+      // between / in over incompatible temporal types
+      expr('date("2024-01-01") between date and time("2024-01-01T00:00:00") and date and time("2024-01-05T00:00:00")', null);
+      expr('date("2024-01-03") in [date and time("2024-01-01T00:00:00")..date and time("2024-01-05T00:00:00")]', null);
+
+      // a comparable member still matches within an <in> list
+      expr('date("2024-01-01") in (date and time("2024-01-01T00:00:00"), date("2024-01-01"))', true);
+
+      // comparisons within the same temporal type keep working
+      expr('date("2024-01-01") < date("2024-01-02")', true);
+      expr('date("2024-01-01") = date("2024-01-01")', true);
+      expr('date and time("2024-01-01T10:00:00") > date and time("2024-01-01T09:00:00")', true);
+      expr('time("10:00:00") < time("11:00:00")', true);
+    });
+
+
     describe('ForExpression > SimplePositiveUnaryTest', function() {
 
       expr(`


### PR DESCRIPTION
Closes #49

## Problem

`date`, `time` and `date and time` are distinct types in FEEL, yet feelin happily compared values across those types:

```feel
date and time("2024-01-01T10:00:00") > date("2024-01-01")   // was: false
date("2024-01-01") = date and time("2024-01-01T00:00:00")   // was: true
```

A comparison between values of different types is not defined in FEEL, so the result should be `null`, not a coerced boolean. This matches the reference behaviour of feel-scala.

## Fix

- **`src/types.ts`** — `equals()` now treats `date`, `time` and `date and time` as mutually incomparable. A regular comparison (`=`, `!=`) yields `null`; strict equality (`is`) still yields `false` (per the DMN TCK).
- **`src/range.ts`** — `rangeIncludes()` returns `null` when the probe and the range are temporal instants of different types. This covers the relational operators (`<`, `>`, `<=`, `>=`), `between` and range membership, which are all implemented via ranges.
- **`src/interpreter.ts`** — `!=` and `in` are now three-valued so an incomparable operand propagates `null` instead of collapsing to a boolean.

## Result

```feel
date and time("2024-01-01T10:00:00") > date("2024-01-01")   // null
date("2024-01-01") = date and time("2024-01-01T00:00:00")   // null
date("2024-01-01") != date and time("2024-01-01T00:00:00")  // null
time("10:00:00") > date("2024-01-01")                       // null
```

Same-type comparisons are unchanged.

## Tests

- New `Comparison > incompatible temporal types` block in `test/interpreter-spec.js` covering `=`, `!=`, `<`, `>`, `<=`, `>=`, `between` and `in` across mismatched temporal types, plus same-type regressions.
- Updated three `test/builtins-spec.js` cases that previously asserted the buggy cross-type equality.

## Note

This PR overlaps with #154 (incompatible-type comparisons → `null`). Both touch the comparison path and will need a trivial conflict resolution on merge; #154 keeps `date` and `date and time` grouped, whereas this PR splits them per #49.
